### PR TITLE
Add hot reload collections

### DIFF
--- a/src/stac_fastapi/geoparquet/api.py
+++ b/src/stac_fastapi/geoparquet/api.py
@@ -1,15 +1,17 @@
-import asyncio
 import json
+import logging
 import urllib.parse
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, TypedDict, cast
 
 import obstore.store
 import pystac.utils
-from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi import FastAPI, Request, Response
 from rustac import DuckdbClient
+from starlette.background import BackgroundTask
 from stac_fastapi.api.app import StacApi
 
 from .client import Client
@@ -21,12 +23,9 @@ from .models import (
 )
 from .settings import Settings
 
-GEOPARQUET_MEDIA_TYPE = "application/vnd.apache.parquet"
+logger = logging.getLogger(__name__)
 
-# Global cache for collections and reload control
-_collections_cache = None
-_collections_cache_lock = asyncio.Lock()
-_collections_cache_last_load = 0.0
+GEOPARQUET_MEDIA_TYPE = "application/vnd.apache.parquet"
 
 
 async def load_collections(settings: Settings) -> list[dict[str, Any]]:
@@ -46,22 +45,29 @@ async def load_collections(settings: Settings) -> list[dict[str, Any]]:
     return collections
 
 
-async def collections_cache_refresher(settings: Settings) -> None:
-    global _collections_cache, _collections_cache_last_load
-    while True:
-        async with _collections_cache_lock:
-            _collections_cache = await load_collections(settings)
-            _collections_cache_last_load = asyncio.get_event_loop().time()
-        await asyncio.sleep(settings.stac_fastapi_collections_reload_seconds)
-
-
-async def get_cached_collections(settings: Settings) -> list[dict[str, Any]]:
-    global _collections_cache, _collections_cache_last_load
-    async with _collections_cache_lock:
-        if _collections_cache is None:
-            _collections_cache = await load_collections(settings)
-            _collections_cache_last_load = asyncio.get_event_loop().time()
-        return _collections_cache
+def _parse_collections(
+    collections: list[dict[str, Any]], settings: Settings
+) -> tuple[dict[str, dict[str, Any]], dict[str, str]]:
+    """Parse a raw collections list into (collection_dict, hrefs)."""
+    collection_dict: dict[str, dict[str, Any]] = {}
+    hrefs: dict[str, str] = {}
+    for collection in collections:
+        collection_id = collection["id"]
+        if collection_id in collection_dict:
+            raise ValueError(f"two collections with the same id: {collection_id}")
+        collection_dict[collection_id] = collection
+        for asset in collection["assets"].values():
+            if asset.get("type") == GEOPARQUET_MEDIA_TYPE:
+                if collection_id in hrefs:
+                    raise ValueError(
+                        f"two hrefs for one collection: {collection_id}"
+                    )
+                hrefs[collection_id] = pystac.utils.make_absolute_href(
+                    asset["href"],
+                    settings.stac_fastapi_collections_href,
+                    start_is_dir=False,
+                )
+    return collection_dict, hrefs
 
 
 class State(TypedDict):
@@ -73,45 +79,56 @@ class State(TypedDict):
     It's just an in-memory DuckDB connection with the spatial extension enabled.
     """
 
-    collections: dict[str, dict[str, Any]]
-    """A mapping of collection id to collection."""
 
-    hrefs: dict[str, str]
-    """A mapping of collection id to geoparquet href."""
-
-
-# Middleware to inject latest collections/hrefs into request.state
-def collections_hot_reload_middleware(
+def make_collections_middleware(
     settings: Settings,
 ) -> Callable[[Request, Callable[[Request], Awaitable[Response]]], Awaitable[Response]]:
+    """Return a TTL-based hot-reload middleware for collections.
+
+    On every request the current ``app.state.collections`` / ``app.state.hrefs``
+    are injected into ``request.state`` so that the rest of the stack is
+    unaffected.  After the response is sent, a background task re-reads
+    ``collections.json`` from object storage and updates ``app.state`` when the
+    configured TTL has elapsed — the same pattern used by tipg's
+    ``CatalogUpdateMiddleware``.
+    """
+
+    async def _refresh(app: FastAPI) -> None:
+        try:
+            raw = await load_collections(settings)
+            collection_dict, hrefs = _parse_collections(raw, settings)
+        except Exception:
+            logger.exception("Failed to reload collections; keeping stale state")
+            return
+        app.state.collections = collection_dict
+        app.state.hrefs = hrefs
+        app.state.collections_last_updated = datetime.now()
+        logger.debug("Collections reloaded; %d collection(s) active", len(collection_dict))
+
     async def middleware(
         request: Request, call_next: Callable[[Request], Awaitable[Response]]
     ) -> Response:
-        collections = await get_cached_collections(settings)
-        collection_dict = dict()
-        hrefs = dict()
-        for collection in collections:
-            if collection["id"] in collection_dict:
-                raise HTTPException(
-                    500, f"two collections with the same id: {collection['id']}"
-                )
-            else:
-                collection_dict[collection["id"]] = collection
-            for key, asset in collection["assets"].items():
-                if asset.get("type") == GEOPARQUET_MEDIA_TYPE:
-                    if collection["id"] in hrefs:
-                        raise HTTPException(
-                            500, f"two hrefs for one collection: {collection['id']}"
-                        )
-                    else:
-                        hrefs[collection["id"]] = pystac.utils.make_absolute_href(
-                            asset["href"],
-                            settings.stac_fastapi_collections_href,
-                            start_is_dir=False,
-                        )
-        request.state.collections = collection_dict
-        request.state.hrefs = hrefs
+        # Propagate the current (possibly cached) state into this request.
+        request.state.collections = request.app.state.collections
+        request.state.hrefs = request.app.state.hrefs
+
+        # Trigger a background refresh when the TTL has expired.
+        background: BackgroundTask | None = None
+        last_updated: datetime | None = getattr(
+            request.app.state, "collections_last_updated", None
+        )
+        ttl = settings.stac_fastapi_collections_reload_seconds
+        if last_updated is None or datetime.now() > last_updated + timedelta(
+            seconds=ttl
+        ):
+            # Optimistically advance the timestamp so concurrent requests
+            # during the same window don't all queue a refresh.
+            request.app.state.collections_last_updated = datetime.now()
+            background = BackgroundTask(_refresh, request.app)
+
         response = await call_next(request)
+        if background is not None:
+            response.background = background
         return response
 
     return middleware
@@ -119,18 +136,18 @@ def collections_hot_reload_middleware(
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[State]:
-    client = app.extra["duckdb_client"]
+    client: DuckdbClient = app.extra["duckdb_client"]
     settings: Settings = app.extra["settings"]
-    # Start background refresher
-    app.state._collections_refresher = asyncio.create_task(
-        collections_cache_refresher(settings)
-    )
-    yield {
-        "client": client,
-        "collections": {},
-        "hrefs": {},
-    }
-    app.state._collections_refresher.cancel()
+
+    # Perform an initial blocking load so the first request is never served
+    # with an empty catalog.
+    raw = await load_collections(settings)
+    collection_dict, hrefs = _parse_collections(raw, settings)
+    app.state.collections = collection_dict
+    app.state.hrefs = hrefs
+    app.state.collections_last_updated = datetime.now()
+
+    yield {"client": client}
 
 
 def create(
@@ -146,7 +163,9 @@ def create(
             stac_fastapi_description="A stac-fastapi server backend by stac-geoparquet",
         )
 
-    # collections will be loaded and cached by the refresher
+    # Collections from stac_fastapi_collections_href are loaded in the lifespan
+    # and kept fresh by the hot-reload middleware.
+    # Collections from stac_fastapi_geoparquet_href are static (loaded once here).
     collections = []
     if settings.stac_fastapi_geoparquet_href:
         collections.extend(
@@ -166,7 +185,7 @@ def create(
         duckdb_client=duckdb_client,
     )
     # Add hot-reload middleware
-    app.middleware("http")(collections_hot_reload_middleware(settings))
+    app.middleware("http")(make_collections_middleware(settings))
 
     api = StacApi(
         settings=settings,

--- a/src/stac_fastapi/geoparquet/api.py
+++ b/src/stac_fastapi/geoparquet/api.py
@@ -11,8 +11,8 @@ import obstore.store
 import pystac.utils
 from fastapi import FastAPI, Request, Response
 from rustac import DuckdbClient
-from starlette.background import BackgroundTask
 from stac_fastapi.api.app import StacApi
+from starlette.background import BackgroundTask
 
 from .client import Client
 from .models import (
@@ -59,9 +59,7 @@ def _parse_collections(
         for asset in collection["assets"].values():
             if asset.get("type") == GEOPARQUET_MEDIA_TYPE:
                 if collection_id in hrefs:
-                    raise ValueError(
-                        f"two hrefs for one collection: {collection_id}"
-                    )
+                    raise ValueError(f"two hrefs for one collection: {collection_id}")
                 hrefs[collection_id] = pystac.utils.make_absolute_href(
                     asset["href"],
                     settings.stac_fastapi_collections_href,
@@ -89,8 +87,7 @@ def make_collections_middleware(
     are injected into ``request.state`` so that the rest of the stack is
     unaffected.  After the response is sent, a background task re-reads
     ``collections.json`` from object storage and updates ``app.state`` when the
-    configured TTL has elapsed — the same pattern used by tipg's
-    ``CatalogUpdateMiddleware``.
+    configured TTL has elapsed.
     """
 
     async def _refresh(app: FastAPI) -> None:
@@ -103,16 +100,16 @@ def make_collections_middleware(
         app.state.collections = collection_dict
         app.state.hrefs = hrefs
         app.state.collections_last_updated = datetime.now()
-        logger.debug("Collections reloaded; %d collection(s) active", len(collection_dict))
+        logger.debug(
+            "Collections reloaded; %d collection(s) active", len(collection_dict)
+        )
 
     async def middleware(
         request: Request, call_next: Callable[[Request], Awaitable[Response]]
     ) -> Response:
-        # Propagate the current (possibly cached) state into this request.
         request.state.collections = request.app.state.collections
         request.state.hrefs = request.app.state.hrefs
 
-        # Trigger a background refresh when the TTL has expired.
         background: BackgroundTask | None = None
         last_updated: datetime | None = getattr(
             request.app.state, "collections_last_updated", None
@@ -121,8 +118,6 @@ def make_collections_middleware(
         if last_updated is None or datetime.now() > last_updated + timedelta(
             seconds=ttl
         ):
-            # Optimistically advance the timestamp so concurrent requests
-            # during the same window don't all queue a refresh.
             request.app.state.collections_last_updated = datetime.now()
             background = BackgroundTask(_refresh, request.app)
 

--- a/src/stac_fastapi/geoparquet/api.py
+++ b/src/stac_fastapi/geoparquet/api.py
@@ -1,16 +1,14 @@
+import asyncio
 import json
 import urllib.parse
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
-from fastapi import Request
 from pathlib import Path
-from typing import Any, TypedDict
+from typing import Any, TypedDict, cast
 
 import obstore.store
 import pystac.utils
-from fastapi import FastAPI, HTTPException
-from fastapi import BackgroundTasks
-import asyncio
+from fastapi import FastAPI, HTTPException, Request, Response
 from rustac import DuckdbClient
 from stac_fastapi.api.app import StacApi
 
@@ -23,7 +21,6 @@ from .models import (
 )
 from .settings import Settings
 
-
 GEOPARQUET_MEDIA_TYPE = "application/vnd.apache.parquet"
 
 # Global cache for collections and reload control
@@ -31,27 +28,32 @@ _collections_cache = None
 _collections_cache_lock = asyncio.Lock()
 _collections_cache_last_load = 0.0
 
+
 async def load_collections(settings: Settings) -> list[dict[str, Any]]:
     if settings.stac_fastapi_collections_href:
         if urllib.parse.urlparse(settings.stac_fastapi_collections_href).scheme:
             href = settings.stac_fastapi_collections_href
         else:
-            href = "file://" + str(Path(settings.stac_fastapi_collections_href).absolute())
+            href = "file://" + str(
+                Path(settings.stac_fastapi_collections_href).absolute()
+            )
         prefix, file_name = href.rsplit("/", 1)
         store = obstore.store.from_url(prefix)
         result = store.get(file_name)
-        collections = json.loads(bytes(result.bytes()))
+        collections = cast(list[dict[str, Any]], json.loads(bytes(result.bytes())))
     else:
         collections = []
     return collections
 
-async def collections_cache_refresher(settings: Settings):
+
+async def collections_cache_refresher(settings: Settings) -> None:
     global _collections_cache, _collections_cache_last_load
     while True:
         async with _collections_cache_lock:
             _collections_cache = await load_collections(settings)
             _collections_cache_last_load = asyncio.get_event_loop().time()
         await asyncio.sleep(settings.stac_fastapi_collections_reload_seconds)
+
 
 async def get_cached_collections(settings: Settings) -> list[dict[str, Any]]:
     global _collections_cache, _collections_cache_last_load
@@ -78,10 +80,13 @@ class State(TypedDict):
     """A mapping of collection id to geoparquet href."""
 
 
-
 # Middleware to inject latest collections/hrefs into request.state
-def collections_hot_reload_middleware(settings: Settings):
-    async def middleware(request: Request, call_next):
+def collections_hot_reload_middleware(
+    settings: Settings,
+) -> Callable[[Request, Callable[[Request], Awaitable[Response]]], Awaitable[Response]]:
+    async def middleware(
+        request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
         collections = await get_cached_collections(settings)
         collection_dict = dict()
         hrefs = dict()
@@ -108,17 +113,24 @@ def collections_hot_reload_middleware(settings: Settings):
         request.state.hrefs = hrefs
         response = await call_next(request)
         return response
+
     return middleware
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[State]:
     client = app.extra["duckdb_client"]
     settings: Settings = app.extra["settings"]
     # Start background refresher
-    app.state._collections_refresher = asyncio.create_task(collections_cache_refresher(settings))
-    yield {"client": client}
+    app.state._collections_refresher = asyncio.create_task(
+        collections_cache_refresher(settings)
+    )
+    yield {
+        "client": client,
+        "collections": {},
+        "hrefs": {},
+    }
     app.state._collections_refresher.cancel()
-
 
 
 def create(

--- a/src/stac_fastapi/geoparquet/api.py
+++ b/src/stac_fastapi/geoparquet/api.py
@@ -2,12 +2,15 @@ import json
 import urllib.parse
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from fastapi import Request
 from pathlib import Path
 from typing import Any, TypedDict
 
 import obstore.store
 import pystac.utils
 from fastapi import FastAPI, HTTPException
+from fastapi import BackgroundTasks
+import asyncio
 from rustac import DuckdbClient
 from stac_fastapi.api.app import StacApi
 
@@ -20,7 +23,43 @@ from .models import (
 )
 from .settings import Settings
 
+
 GEOPARQUET_MEDIA_TYPE = "application/vnd.apache.parquet"
+
+# Global cache for collections and reload control
+_collections_cache = None
+_collections_cache_lock = asyncio.Lock()
+_collections_cache_last_load = 0.0
+
+async def load_collections(settings: Settings) -> list[dict[str, Any]]:
+    if settings.stac_fastapi_collections_href:
+        if urllib.parse.urlparse(settings.stac_fastapi_collections_href).scheme:
+            href = settings.stac_fastapi_collections_href
+        else:
+            href = "file://" + str(Path(settings.stac_fastapi_collections_href).absolute())
+        prefix, file_name = href.rsplit("/", 1)
+        store = obstore.store.from_url(prefix)
+        result = store.get(file_name)
+        collections = json.loads(bytes(result.bytes()))
+    else:
+        collections = []
+    return collections
+
+async def collections_cache_refresher(settings: Settings):
+    global _collections_cache, _collections_cache_last_load
+    while True:
+        async with _collections_cache_lock:
+            _collections_cache = await load_collections(settings)
+            _collections_cache_last_load = asyncio.get_event_loop().time()
+        await asyncio.sleep(settings.stac_fastapi_collections_reload_seconds)
+
+async def get_cached_collections(settings: Settings) -> list[dict[str, Any]]:
+    global _collections_cache, _collections_cache_last_load
+    async with _collections_cache_lock:
+        if _collections_cache is None:
+            _collections_cache = await load_collections(settings)
+            _collections_cache_last_load = asyncio.get_event_loop().time()
+        return _collections_cache
 
 
 class State(TypedDict):
@@ -39,37 +78,47 @@ class State(TypedDict):
     """A mapping of collection id to geoparquet href."""
 
 
+
+# Middleware to inject latest collections/hrefs into request.state
+def collections_hot_reload_middleware(settings: Settings):
+    async def middleware(request: Request, call_next):
+        collections = await get_cached_collections(settings)
+        collection_dict = dict()
+        hrefs = dict()
+        for collection in collections:
+            if collection["id"] in collection_dict:
+                raise HTTPException(
+                    500, f"two collections with the same id: {collection['id']}"
+                )
+            else:
+                collection_dict[collection["id"]] = collection
+            for key, asset in collection["assets"].items():
+                if asset.get("type") == GEOPARQUET_MEDIA_TYPE:
+                    if collection["id"] in hrefs:
+                        raise HTTPException(
+                            500, f"two hrefs for one collection: {collection['id']}"
+                        )
+                    else:
+                        hrefs[collection["id"]] = pystac.utils.make_absolute_href(
+                            asset["href"],
+                            settings.stac_fastapi_collections_href,
+                            start_is_dir=False,
+                        )
+        request.state.collections = collection_dict
+        request.state.hrefs = hrefs
+        response = await call_next(request)
+        return response
+    return middleware
+
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[State]:
     client = app.extra["duckdb_client"]
     settings: Settings = app.extra["settings"]
-    collections = app.extra["collections"]
-    collection_dict = dict()
-    hrefs = dict()
-    for collection in collections:
-        if collection["id"] in collection_dict:
-            raise HTTPException(
-                500, f"two collections with the same id: {collection['id']}"
-            )
-        else:
-            collection_dict[collection["id"]] = collection
-        for key, asset in collection["assets"].items():
-            if asset.get("type") == GEOPARQUET_MEDIA_TYPE:
-                if collection["id"] in hrefs:
-                    raise HTTPException(
-                        500, f"two hrefs for one collection: {collection['id']}"
-                    )
-                else:
-                    hrefs[collection["id"]] = pystac.utils.make_absolute_href(
-                        asset["href"],
-                        settings.stac_fastapi_collections_href,
-                        start_is_dir=False,
-                    )
-    yield {
-        "client": client,
-        "collections": collection_dict,
-        "hrefs": hrefs,
-    }
+    # Start background refresher
+    app.state._collections_refresher = asyncio.create_task(collections_cache_refresher(settings))
+    yield {"client": client}
+    app.state._collections_refresher.cancel()
+
 
 
 def create(
@@ -85,20 +134,8 @@ def create(
             stac_fastapi_description="A stac-fastapi server backend by stac-geoparquet",
         )
 
-    if settings.stac_fastapi_collections_href:
-        if urllib.parse.urlparse(settings.stac_fastapi_collections_href).scheme:
-            href = settings.stac_fastapi_collections_href
-        else:
-            href = "file://" + str(
-                Path(settings.stac_fastapi_collections_href).absolute()
-            )
-        prefix, file_name = href.rsplit("/", 1)
-        store = obstore.store.from_url(prefix)
-        result = store.get(file_name)
-        collections = json.loads(bytes(result.bytes()))
-    else:
-        collections = []
-
+    # collections will be loaded and cached by the refresher
+    collections = []
     if settings.stac_fastapi_geoparquet_href:
         collections.extend(
             collections_from_geoparquet_href(
@@ -107,18 +144,22 @@ def create(
             )
         )
 
+    app = FastAPI(
+        lifespan=lifespan,
+        openapi_url=settings.openapi_url,
+        docs_url=settings.docs_url,
+        redoc_url=settings.docs_url,
+        settings=settings,
+        collections=collections,
+        duckdb_client=duckdb_client,
+    )
+    # Add hot-reload middleware
+    app.middleware("http")(collections_hot_reload_middleware(settings))
+
     api = StacApi(
         settings=settings,
         client=Client(),
-        app=FastAPI(
-            lifespan=lifespan,
-            openapi_url=settings.openapi_url,
-            docs_url=settings.docs_url,
-            redoc_url=settings.docs_url,
-            settings=settings,
-            collections=collections,
-            duckdb_client=duckdb_client,
-        ),
+        app=app,
         search_get_request_model=GetSearchRequestModel,
         search_post_request_model=PostSearchRequestModel,
         items_get_request_model=ItemsGetRequestModel,

--- a/src/stac_fastapi/geoparquet/settings.py
+++ b/src/stac_fastapi/geoparquet/settings.py
@@ -1,8 +1,12 @@
 from stac_fastapi.types.config import ApiSettings
 
 
+
 class Settings(ApiSettings):
     """stac-fastapi-geoparquet settings"""
+
+    stac_fastapi_collections_reload_seconds: int = 60
+    """Interval in seconds to reload collections.json (default: 60)."""
 
     stac_fastapi_collections_href: str | None = None
     """The href of a file containing JSON list of collections.

--- a/src/stac_fastapi/geoparquet/settings.py
+++ b/src/stac_fastapi/geoparquet/settings.py
@@ -1,7 +1,6 @@
 from stac_fastapi.types.config import ApiSettings
 
 
-
 class Settings(ApiSettings):
     """stac-fastapi-geoparquet settings"""
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,6 @@
+from datetime import datetime, timedelta
 from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -32,3 +34,55 @@ def test_create_from_parquet_file() -> None:
     with TestClient(api.app) as client:
         response = client.get("/search")
         assert response.status_code == 200
+
+
+def test_collections_reload_on_ttl_expiry() -> None:
+    settings = Settings(
+        stac_fastapi_collections_href=str(COLLECTIONS_PATH),
+        stac_fastapi_collections_reload_seconds=60,
+    )
+    api = stac_fastapi.geoparquet.api.create(settings=settings)
+
+    with TestClient(api.app) as client:
+        # Sanity check: initial collections are populated.
+        response = client.get("/collections")
+        assert len(response.json()["collections"]) > 0
+
+        # Expire the TTL so the next request schedules a background refresh.
+        api.app.state.collections_last_updated = datetime.now() - timedelta(seconds=120)
+
+        # Patch load_collections to return an empty list for the reload.
+        with patch(
+            "stac_fastapi.geoparquet.api.load_collections",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            # TestClient awaits BackgroundTask before returning, so the refresh
+            # has already updated app.state by the time this call returns.
+            client.get("/collections")
+
+        # The next request should see the reloaded (empty) state.
+        response = client.get("/collections")
+        assert response.json()["collections"] == []
+
+
+def test_collections_no_reload_within_ttl() -> None:
+    settings = Settings(
+        stac_fastapi_collections_href=str(COLLECTIONS_PATH),
+        stac_fastapi_collections_reload_seconds=3600,
+    )
+    api = stac_fastapi.geoparquet.api.create(settings=settings)
+
+    with TestClient(api.app) as client:
+        initial_count = len(client.get("/collections").json()["collections"])
+
+        with patch(
+            "stac_fastapi.geoparquet.api.load_collections",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock_load:
+            client.get("/collections")
+            mock_load.assert_not_called()
+
+        # Collections should be unchanged.
+        assert len(client.get("/collections").json()["collections"]) == initial_count


### PR DESCRIPTION
I am serving data with stac-fastapi-geoparquet with a pipeline regularly adds new items to existing parquets and updates the extent of collections.json stored remotely. Since collection.json is load only once when the app starts, we have to restart the service every time after the collection.json is updated.

This is a draft which implements a mechanism to reload and cache collections.json at a set time interval, and all requests will go through the latest cached collection.json. With the hot reload mechanism the updated collections.json can be reflected without restarting the service.

@gadomski What do you think having a hot reload mechanism at the backend? Please let me know if this feature fits to the project, thank you!