### PR TITLE
feat: inject DuckDB client via app.state to allow runtime replacement

### DIFF
--- a/src/stac_fastapi/geoparquet/api.py
+++ b/src/stac_fastapi/geoparquet/api.py
@@ -107,6 +107,7 @@ def make_collections_middleware(
     async def middleware(
         request: Request, call_next: Callable[[Request], Awaitable[Response]]
     ) -> Response:
+        request.state.client = request.app.state.client
         request.state.collections = request.app.state.collections
         request.state.hrefs = request.app.state.hrefs
 
@@ -138,6 +139,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[State]:
     # with an empty catalog.
     raw = await load_collections(settings)
     collection_dict, hrefs = _parse_collections(raw, settings)
+    app.state.client = client
     app.state.collections = collection_dict
     app.state.hrefs = hrefs
     app.state.collections_last_updated = datetime.now()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -87,6 +87,7 @@ def test_collections_no_reload_within_ttl() -> None:
         # Collections should be unchanged.
         assert len(client.get("/collections").json()["collections"]) == initial_count
 
+
 def test_duckdb_client_injected() -> None:
     duckdb_client = DuckdbClient()
     settings = Settings(stac_fastapi_collections_href=str(COLLECTIONS_PATH))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -86,3 +86,21 @@ def test_collections_no_reload_within_ttl() -> None:
 
         # Collections should be unchanged.
         assert len(client.get("/collections").json()["collections"]) == initial_count
+
+def test_duckdb_client_injected() -> None:
+    duckdb_client = DuckdbClient()
+    settings = Settings(stac_fastapi_collections_href=str(COLLECTIONS_PATH))
+    api = stac_fastapi.geoparquet.api.create(
+        duckdb_client=duckdb_client, settings=settings
+    )
+    with TestClient(api.app) as client:
+        response = client.get("/search")
+        assert response.status_code == 200
+        assert api.app.state.client is duckdb_client
+
+        # Replace the client at runtime and verify the new one is used.
+        new_client = DuckdbClient()
+        api.app.state.client = new_client
+        response = client.get("/search")
+        assert response.status_code == 200
+        assert api.app.state.client is new_client

--- a/uv.lock
+++ b/uv.lock
@@ -791,14 +791,14 @@ wheels = [
 
 [[package]]
 name = "mangum"
-version = "0.20.0"
+version = "0.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/76/03462d8f745a12b40d96b674c6d9c4182594571edc28b47d6ddd9a819ed5/mangum-0.20.0.tar.gz", hash = "sha256:0050447b60d832dcc45cc9d917c9e0f4e9174e2d9630f621d567510d51d286bd", size = 128418, upload-time = "2025-12-27T08:48:37.423Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/cb/d9f4d685a0b8eceac10991e15ac471d9568e4e42c2489ae9bf072828c1c2/mangum-0.21.0.tar.gz", hash = "sha256:e31ed72d67f9958fa4379f65df77729906dec6dfa00afa6ed4e06c77833000de", size = 89130, upload-time = "2026-02-01T17:17:42.816Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/67/9398a64b5a97a9125fac1b168917cfa7f9d81eddc23bf50dacd4ff999aed/mangum-0.20.0-py3-none-any.whl", hash = "sha256:c945eadc41916f73b6086c0c69935ef4b1d23d27de8dc74ed47b20e204335407", size = 18024, upload-time = "2025-12-27T08:48:35.686Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/50/e3c694b8e122551e4557450219283771334dee2ed5734a8398c8b8018c50/mangum-0.21.0-py3-none-any.whl", hash = "sha256:309e48f5c629542516c5106ecf079f4ec08809ed50df882238d98fe1392820c7", size = 17146, upload-time = "2026-02-01T17:17:41.553Z" },
 ]
 
 [[package]]
@@ -2099,7 +2099,7 @@ wheels = [
 
 [[package]]
 name = "stac-fastapi-geoparquet"
-version = "0.0.3"
+version = "0.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "attr" },
@@ -2148,7 +2148,7 @@ requires-dist = [
     { name = "attr", specifier = ">=0.3.2" },
     { name = "fastapi", specifier = ">=0.115.8" },
     { name = "geojson-pydantic", specifier = ">=1.2.0" },
-    { name = "mangum", marker = "extra == 'lambda'", specifier = "==0.20.0" },
+    { name = "mangum", marker = "extra == 'lambda'", specifier = "==0.21.0" },
     { name = "obstore", specifier = ">=0.8.0" },
     { name = "pydantic", specifier = ">=2.10.4" },
     { name = "pystac", specifier = ">=1.13.0" },


### PR DESCRIPTION
## Technical Context
- **Related Issues:** Fixes # (issue number)
  - `lifespan()` yields `{"client": client}` into uvicorn's `app_state`.
     uvicorn shallow-copies this dict into `scope["state"]` on every request,
     but the copy source is frozen at startup. Writing to `app.state.client`
     at runtime has no effect on subsequent requests — they still receive the
     original client from the startup snapshot.

     This makes it impossible for operators to replace a stale or broken
     `DuckdbClient` without restarting the server. A common trigger is
     DuckDB's httpfs cache being poisoned during a concurrent parquet file
     rewrite, causing persistent `"No magic bytes found at end of file"` errors.
- **Breaking Changes:** No (If yes, please describe the impact and migration path)

## Description
> Provide a brief summary of the changes, the rationale behind them, and any specific areas you'd like the reviewers to focus on.
- `app.state.client = client` in `lifespan()` to seed FastAPI's mutable state tier
- `request.state.client = request.app.state.client` in `middleware()` to inject the current client on every request, overriding the frozen uvicorn copy  

## Use Case

> We built STAC on top of the library with a pipeline continuously **rewrite** the parquet pointed by the collection. There's an edge case when a request arrives during the parquet rewrite windows. This would poison the duckdb client, which caches parquet's length and e-tag, and require a restart to resolve the corrupted client. The middleware injection allows client replacement at runtime and the issue can be solved without restarting the service.
---

## Checklist
- [x] **Linting:** Code is formatted and linted
- [x] **Tests:** Tests pass. I have included new tests for these changes where applicable.
- [ ] **Edge Cases:** I have manually verified "unhappy paths" and edge cases beyond the basic success criteria (e.g., database connection timeouts, malformed input, strict mapping rejections).
- [ ] **Documentation:** I have updated `README.md` to reflect any new environment variables, configuration changes, or breaking updates.
- [x] **Accountability:** I can explain the implementation logic for every line of code submitted.

---

## AI tool usage
 - [x] AI (Copilot or something similar) supported my development of this PR. See our [policy about AI tool use](https://stac-utils.github.io/ai-contribution-policy). Use of AI tools *must* be indicated.
 ---
 > **Policy:** We require a "human-in-the-loop." You are the author and are fully accountable for all submitted code. Please ensure all tool-generated content is thoroughly reviewed before submission to ensure it is not an "extractive contribution" that squanders maintainer time.