### PR TITLE
fix: serve collections generated from stac_fastapi_geoparquet_href

### DIFF
--- a/src/stac_fastapi/geoparquet/api.py
+++ b/src/stac_fastapi/geoparquet/api.py
@@ -77,9 +77,16 @@ class State(TypedDict):
     It's just an in-memory DuckDB connection with the spatial extension enabled.
     """
 
+    collections: dict[str, dict[str, Any]]
+    """A mapping of collection id to collection."""
+
+    hrefs: dict[str, str]
+    """A mapping of collection id to geoparquet href."""
+
 
 def make_collections_middleware(
     settings: Settings,
+    static_collections: list[dict[str, Any]],
 ) -> Callable[[Request, Callable[[Request], Awaitable[Response]]], Awaitable[Response]]:
     """Return a TTL-based hot-reload middleware for collections.
 
@@ -88,12 +95,18 @@ def make_collections_middleware(
     unaffected.  After the response is sent, a background task re-reads
     ``collections.json`` from object storage and updates ``app.state`` when the
     configured TTL has elapsed.
+
+    ``static_collections`` are the ones generated from
+    ``stac_fastapi_geoparquet_href``, which have no file to be re-read from;
+    they're carried across each reload so a refresh doesn't drop them.
     """
 
     async def _refresh(app: FastAPI) -> None:
         try:
             raw = await load_collections(settings)
-            collection_dict, hrefs = _parse_collections(raw, settings)
+            collection_dict, hrefs = _parse_collections(
+                static_collections + raw, settings
+            )
         except Exception:
             logger.exception("Failed to reload collections; keeping stale state")
             return
@@ -136,15 +149,22 @@ async def lifespan(app: FastAPI) -> AsyncIterator[State]:
     settings: Settings = app.extra["settings"]
 
     # Perform an initial blocking load so the first request is never served
-    # with an empty catalog.
+    # with an empty catalog. Collections auto-generated from
+    # `stac_fastapi_geoparquet_href` are built once in `create()` and arrive
+    # via `app.extra`; they aren't re-read, since nothing about them changes
+    # unless the file itself is replaced.
     raw = await load_collections(settings)
-    collection_dict, hrefs = _parse_collections(raw, settings)
+    collection_dict, hrefs = _parse_collections(
+        app.extra["collections"] + raw, settings
+    )
     app.state.client = client
     app.state.collections = collection_dict
     app.state.hrefs = hrefs
     app.state.collections_last_updated = datetime.now()
 
-    yield {"client": client}
+    # Also part of the request state, so requests are served correctly when
+    # the hot-reload middleware isn't installed (see `create`).
+    yield {"client": client, "collections": collection_dict, "hrefs": hrefs}
 
 
 def create(
@@ -181,8 +201,12 @@ def create(
         collections=collections,
         duckdb_client=duckdb_client,
     )
-    # Add hot-reload middleware
-    app.middleware("http")(make_collections_middleware(settings))
+    # The middleware exists to re-read `collections.json`, so it's only worth
+    # installing when there is one. Without it the request state comes
+    # straight from the lifespan, which is all a catalog generated from
+    # `stac_fastapi_geoparquet_href` needs.
+    if settings.stac_fastapi_collections_href:
+        app.middleware("http")(make_collections_middleware(settings, collections))
 
     api = StacApi(
         settings=settings,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -34,6 +34,20 @@ def test_create_from_parquet_file() -> None:
     with TestClient(api.app) as client:
         response = client.get("/search")
         assert response.status_code == 200
+        assert len(response.json()["features"]) > 0
+
+        response = client.get("/collections")
+        assert [c["id"] for c in response.json()["collections"]] == ["naip"]
+
+        response = client.get("/collections/naip")
+        assert response.status_code == 200
+
+        # There is no collections.json to re-read, so no hot-reload middleware
+        # is installed and nothing can empty the catalog behind us.
+        api.app.state.collections_last_updated = datetime.now() - timedelta(seconds=120)
+        client.get("/collections")
+        response = client.get("/collections")
+        assert [c["id"] for c in response.json()["collections"]] == ["naip"]
 
 
 def test_collections_reload_on_ttl_expiry() -> None:
@@ -105,3 +119,33 @@ def test_duckdb_client_injected() -> None:
         response = client.get("/search")
         assert response.status_code == 200
         assert api.app.state.client is new_client
+
+
+def test_create_from_both_hrefs(tmp_path: Path) -> None:
+    # Both sources configured at once: the hot-reload middleware is installed
+    # for collections.json, and must not drop the parquet-generated ones.
+    # The checked-in fixtures all appear in collections.json, so rename the
+    # collection in a copy to avoid a duplicate id.
+    standalone = tmp_path / "standalone.parquet"
+    DuckdbClient().execute(
+        f"COPY (SELECT * REPLACE ('standalone' AS collection) "
+        f"FROM read_parquet('{NAIP_PATH}')) TO '{standalone}' (FORMAT PARQUET);"
+    )
+    settings = Settings(
+        stac_fastapi_collections_href=str(COLLECTIONS_PATH),
+        stac_fastapi_geoparquet_href=str(standalone),
+    )
+    api = stac_fastapi.geoparquet.api.create(settings=settings)
+    with TestClient(api.app) as client:
+        response = client.get("/collections")
+        ids = [c["id"] for c in response.json()["collections"]]
+        assert "standalone" in ids  # from the parquet file
+        assert "openaerialmap" in ids  # from collections.json
+
+        # Survives a reload, too.
+        api.app.state.collections_last_updated = datetime.now() - timedelta(seconds=120)
+        client.get("/collections")
+        response = client.get("/collections")
+        ids = [c["id"] for c in response.json()["collections"]]
+        assert "standalone" in ids
+        assert "openaerialmap" in ids


### PR DESCRIPTION
Configuring the server with only `stac_fastapi_geoparquet_href` currently serves an empty catalog: `/collections` returns `[]` and `/search` returns no features.

Since the collections hot-reload landed, `lifespan` builds its state purely from `load_collections(settings)`, which reads `stac_fastapi_collections_href`. The collections auto-generated from `stac_fastapi_geoparquet_href` are built in `create()` and handed over through `app.extra["collections"]`, and nothing reads that any more.

This merges those static collections into the state on the initial load and on every reload.

### Why CI didn't catch it

`test_create_from_parquet_file` only asserted a 200, which an empty catalog satisfies. It now checks that the items and the collection are actually there — and fails on `main` without the fix:

```
FAILED tests/test_api.py::test_create_from_parquet_file - assert 0 > 0
```

### Verification

`scripts/lint` and `scripts/test` pass.
