### PR TITLE
feat: support the Query extension by translating it to CQL2

### DIFF
--- a/src/stac_fastapi/geoparquet/client.py
+++ b/src/stac_fastapi/geoparquet/client.py
@@ -18,6 +18,91 @@ from .models import PostSearchRequestModel
 DEFAULT_LIMIT = 10_000
 
 
+# rustac's DuckdbClient does not implement the STAC Query Extension's `query`
+# parameter directly (it raises `RustacError: query is not implemented`), so
+# it must be translated into an equivalent CQL2 filter before being forwarded.
+_QUERY_EXT_OPERATORS = {
+    "eq": "=",
+    "neq": "<>",
+    "lt": "<",
+    "lte": "<=",
+    "gt": ">",
+    "gte": ">=",
+}
+
+
+def _cql2_text_identifier(prop: str) -> str:
+    """Quote a property name for CQL2-text so it can't inject filter syntax."""
+    return '"' + prop.replace('"', '""') + '"'
+
+
+def _cql2_text_literal(value: Any) -> str:
+    if isinstance(value, str):
+        return "'" + value.replace("'", "''") + "'"
+    if isinstance(value, bool):
+        return "TRUE" if value else "FALSE"
+    if value is None:
+        return "NULL"
+    return str(value)
+
+
+def _query_ext_to_cql2_text(query: dict[str, dict[str, Any]]) -> str:
+    """Translate a STAC Query Extension object into a CQL2-text filter."""
+    clauses = []
+    for prop, ops in query.items():
+        ident = _cql2_text_identifier(prop)
+        for op, value in ops.items():
+            if op in _QUERY_EXT_OPERATORS:
+                clauses.append(
+                    f"{ident} {_QUERY_EXT_OPERATORS[op]} {_cql2_text_literal(value)}"
+                )
+            elif op == "in":
+                values = ", ".join(_cql2_text_literal(v) for v in value)
+                clauses.append(f"{ident} IN ({values})")
+            elif op == "startsWith":
+                clauses.append(f"{ident} LIKE {_cql2_text_literal(f'{value}%')}")
+            elif op == "endsWith":
+                clauses.append(f"{ident} LIKE {_cql2_text_literal(f'%{value}')}")
+            elif op == "contains":
+                clauses.append(f"{ident} LIKE {_cql2_text_literal(f'%{value}%')}")
+            else:
+                raise HTTPException(400, f"Unsupported query operator: {op!r}")
+    return " AND ".join(clauses)
+
+
+def _query_ext_to_cql2_json(query: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    """Translate a STAC Query Extension object into a CQL2-json filter."""
+    clauses: list[dict[str, Any]] = []
+    for prop, ops in query.items():
+        for op, value in ops.items():
+            if op in _QUERY_EXT_OPERATORS:
+                clauses.append(
+                    {
+                        "op": _QUERY_EXT_OPERATORS[op],
+                        "args": [{"property": prop}, value],
+                    }
+                )
+            elif op == "in":
+                clauses.append({"op": "in", "args": [{"property": prop}, list(value)]})
+            elif op == "startsWith":
+                clauses.append(
+                    {"op": "like", "args": [{"property": prop}, f"{value}%"]}
+                )
+            elif op == "endsWith":
+                clauses.append(
+                    {"op": "like", "args": [{"property": prop}, f"%{value}"]}
+                )
+            elif op == "contains":
+                clauses.append(
+                    {"op": "like", "args": [{"property": prop}, f"%{value}%"]}
+                )
+            else:
+                raise HTTPException(400, f"Unsupported query operator: {op!r}")
+    if len(clauses) == 1:
+        return clauses[0]
+    return {"op": "and", "args": clauses}
+
+
 class Client(BaseCoreClient):
     """A stac-fastapi-geoparquet client."""
 
@@ -76,7 +161,10 @@ class Client(BaseCoreClient):
         request = kwargs.pop("request")
 
         if intersects:
-            maybe_intersects = json.loads(intersects)
+            try:
+                maybe_intersects = json.loads(intersects)
+            except json.JSONDecodeError as e:
+                raise HTTPException(400, f"invalid intersects: {e}")
         else:
             maybe_intersects = None
 
@@ -167,10 +255,18 @@ class Client(BaseCoreClient):
         search_dict.pop("filter_crs", None)
         if filter_expr := search_dict.pop("filter_expr", None):
             search_dict["filter"] = filter_expr
-        if filter_lang := search_dict.pop("filter_lang", None):
+        # The key varies by request method: POST's `search_dict` comes from
+        # `model_dump(by_alias=True)`, which uses the pydantic alias
+        # "filter-lang" (hyphen); GET's arrives via **kwargs from a FastAPI
+        # dependency function, which can only use the valid identifier
+        # "filter_lang" (underscore). Read both, so the `query` translation
+        # below always sees the language the caller actually asked for.
+        filter_lang: str | None = search_dict.pop(
+            "filter-lang", None
+        ) or search_dict.pop("filter_lang", None)
+        if filter_lang:
             search_dict["filter-lang"] = filter_lang
         if "filter" not in search_dict:
-            search_dict.pop("filter_lang", None)
             search_dict.pop("filter-lang", None)
         if fields := search_dict.pop("fields", None):
             if isinstance(fields, list):
@@ -193,6 +289,41 @@ class Client(BaseCoreClient):
                 raise HTTPException(400, f"unexpected fields type: {fields}")
         if sortby := search_dict.pop("sortby", None):
             search_dict["sortby"] = sortby
+
+        # Translate the Query Extension's `query` into an equivalent CQL2
+        # filter — rustac's DuckdbClient only understands `filter`/CQL2 and
+        # raises RustacError("query is not implemented") if `query` reaches it.
+        if query := search_dict.pop("query", None):
+            # On GET requests `query` arrives as a JSON-encoded string.
+            if isinstance(query, str):
+                try:
+                    query = json.loads(query)
+                except json.JSONDecodeError as e:
+                    raise HTTPException(400, f"invalid query: {e}")
+            if not isinstance(query, dict):
+                raise HTTPException(400, "invalid query: expected a JSON object")
+            filter_lang = filter_lang or "cql2-text"
+            if filter_lang == "cql2-text":
+                query_filter: Any = _query_ext_to_cql2_text(query)
+                search_dict["filter"] = (
+                    f"({search_dict['filter']}) AND ({query_filter})"
+                    if search_dict.get("filter")
+                    else query_filter
+                )
+            elif filter_lang == "cql2-json":
+                query_filter = _query_ext_to_cql2_json(query)
+                search_dict["filter"] = (
+                    {"op": "and", "args": [search_dict["filter"], query_filter]}
+                    if search_dict.get("filter")
+                    else query_filter
+                )
+            else:
+                raise HTTPException(
+                    400,
+                    f"Unsupported filter-lang for the 'query' extension: "
+                    f"{filter_lang!r}",
+                )
+            search_dict["filter-lang"] = filter_lang
 
         limit = search_dict.get("limit", DEFAULT_LIMIT)
         offset = search_dict.get("offset", 0) or 0

--- a/src/stac_fastapi/geoparquet/models.py
+++ b/src/stac_fastapi/geoparquet/models.py
@@ -3,6 +3,7 @@ from stac_fastapi.api.models import ItemCollectionUri
 from stac_fastapi.extensions.core.fields import FieldsExtension
 from stac_fastapi.extensions.core.filter import SearchFilterExtension
 from stac_fastapi.extensions.core.pagination import OffsetPaginationExtension
+from stac_fastapi.extensions.core.query import QueryExtension
 from stac_fastapi.extensions.core.sort import SortExtension
 from stac_fastapi.types.search import BaseSearchPostRequest
 
@@ -12,6 +13,7 @@ EXTENSIONS = [
     OffsetPaginationExtension(),
     SearchFilterExtension(),
     FieldsExtension(),
+    QueryExtension(),
     SortExtension(),
 ]
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -107,6 +107,76 @@ def test_filter_post(client: TestClient) -> None:
     assert len(response.json()["features"]) == 0
 
 
+def test_query_ext_post(client: TestClient) -> None:
+    params = {"limit": 1, "query": {"naip:year": {"eq": "2022"}}}
+    response = client.post("/search", json=params)
+    response.raise_for_status()
+    assert len(response.json()["features"]) == 1
+    assert response.json()["features"][0]["properties"]["naip:year"] == "2022"
+
+    params = {"limit": 1, "query": {"naip:year": {"eq": "notayear"}}}
+    response = client.post("/search", json=params)
+    response.raise_for_status()
+    assert not response.json()["features"]
+
+
+def test_query_ext_get(client: TestClient) -> None:
+    # On GET requests `query` arrives as a JSON-encoded string.
+    params = {"limit": 1, "query": '{"naip:year": {"eq": "2022"}}'}
+    response = client.get("/search", params=params)
+    response.raise_for_status()
+    assert len(response.json()["features"]) == 1
+    assert response.json()["features"][0]["properties"]["naip:year"] == "2022"
+
+    params = {"limit": 1, "query": '{"naip:year": {"eq": "notayear"}}'}
+    response = client.get("/search", params=params)
+    response.raise_for_status()
+    assert not response.json()["features"]
+
+
+def test_query_ext_operators(client: TestClient) -> None:
+    for query, expected in (
+        ({"naip:year": {"neq": "2022"}}, lambda y: y != "2022"),
+        ({"naip:year": {"in": ["2022"]}}, lambda y: y == "2022"),
+        ({"naip:year": {"startsWith": "202"}}, lambda y: y.startswith("202")),
+    ):
+        response = client.post("/search", json={"limit": 5, "query": query})
+        response.raise_for_status()
+        features = response.json()["features"]
+        assert features, query
+        for feature in features:
+            assert expected(feature["properties"]["naip:year"]), query
+
+
+def test_query_ext_get_invalid_json(client: TestClient) -> None:
+    response = client.get("/search", params={"query": "{not json"})
+    assert response.status_code == 400
+
+
+def test_query_ext_unsupported_operator(client: TestClient) -> None:
+    response = client.post("/search", json={"query": {"naip:year": {"wat": "2022"}}})
+    assert response.status_code == 400
+
+
+def test_query_ext_combines_with_filter(client: TestClient) -> None:
+    params = {
+        "limit": 10,
+        "filter": {"op": "=", "args": [{"property": "naip:year"}, "2022"]},
+        "query": {"naip:state": {"eq": "ne"}},
+    }
+    response = client.post("/search", json=params)
+    response.raise_for_status()
+    assert response.json()["features"]
+    for feature in response.json()["features"]:
+        assert feature["properties"]["naip:year"] == "2022"
+        assert feature["properties"]["naip:state"] == "ne"
+
+
+def test_400_intersects(client: TestClient) -> None:
+    response = client.get("/search", params={"intersects": "{not json"})
+    assert response.status_code == 400
+
+
 def test_paging_filter(client: TestClient) -> None:
     params = {"limit": 1, "filter": "naip:year='2022'"}
     response = client.get("/search", params=params)


### PR DESCRIPTION
rustac's `DuckdbClient` doesn't implement the Query extension — a `query` parameter reaching it raises `RustacError: query is not implemented` — so the extension wasn't advertised and `query` was rejected as an unknown parameter.

This translates it into the equivalent CQL2 filter instead, in whichever language the caller is using, and ANDs it with any `filter` they also supplied. Supported operators: `eq`, `neq`, `lt`, `lte`, `gt`, `gte`, `in`, `startsWith`, `endsWith`, `contains`. Anything else is a 400 rather than a backend error.

Property names and string literals are quoted on the way in, so a property name can't inject filter syntax.

### One prerequisite worth flagging

The translation needs to know the caller's filter language, and `filter-lang` arrives under two different spellings: POST's `search_dict` comes from `model_dump(by_alias=True)` and carries the pydantic alias `"filter-lang"`, while GET's arrives through a FastAPI dependency function, which can only name it `"filter_lang"`. Both are now read.

Also turns a malformed `intersects` into a 400 instead of an uncaught `JSONDecodeError`.

### Verification

New tests cover POST, GET (where `query` arrives JSON-encoded), the operator set, combination with an existing `filter`, and the 400 paths. `scripts/lint` and `scripts/test` pass.
