### PR TITLE
feat: add the queryables endpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,14 @@ description = "A stac-fastapi implementation with a stac-geoparquet backend"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
+    "arro3-core>=0.8.0",
     "attr>=0.3.2",
     "fastapi>=0.115.8",
     "geojson-pydantic>=1.2.0",
     "obstore>=0.8.0",
     "pydantic>=2.10.4",
     "pystac>=1.13.0",
-    "rustac>=0.7.0",
+    "rustac>=0.9.11",
     "stac-fastapi-api>=5.0.2",
     "stac-fastapi-extensions>=5.0.2",
     "stac-fastapi-types>=5.0.2",

--- a/src/stac_fastapi/geoparquet/client.py
+++ b/src/stac_fastapi/geoparquet/client.py
@@ -348,5 +348,13 @@ def collection_with_links(collection: Collection, request: Request) -> Collectio
             "rel": "items",
             "type": "application/geo+json",
         },
+        {
+            "href": str(
+                request.url_for("Collection Queryables", collection_id=collection["id"])
+            ),
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+            "type": "application/schema+json",
+            "title": "Queryables",
+        },
     ]
     return collection

--- a/src/stac_fastapi/geoparquet/filters.py
+++ b/src/stac_fastapi/geoparquet/filters.py
@@ -1,0 +1,277 @@
+"""
+Filter extension client for stac-fastapi-geoparquet.
+Implements ``/queryables`` and ``/collections/{collection_id}/queryables``
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from rustac import DuckdbClient
+from stac_fastapi.extensions.core.filter.client import BaseFiltersClient
+from stac_fastapi.types.errors import NotFoundError
+from starlette.requests import Request
+
+# ---------------------------------------------------------------------------
+# DuckDB type → JSON-Schema type mapping (AI written)
+# ---------------------------------------------------------------------------
+
+_DUCKDB_TO_JSONSCHEMA: dict[str, dict[str, str]] = {
+    # strings
+    "VARCHAR": {"type": "string"},
+    "TEXT": {"type": "string"},
+    # integers
+    "BIGINT": {"type": "integer"},
+    "INTEGER": {"type": "integer"},
+    "INT": {"type": "integer"},
+    "SMALLINT": {"type": "integer"},
+    "TINYINT": {"type": "integer"},
+    "HUGEINT": {"type": "integer"},
+    "UBIGINT": {"type": "integer"},
+    "UINTEGER": {"type": "integer"},
+    "USMALLINT": {"type": "integer"},
+    "UTINYINT": {"type": "integer"},
+    # numbers
+    "DOUBLE": {"type": "number"},
+    "FLOAT": {"type": "number"},
+    "REAL": {"type": "number"},
+    "DECIMAL": {"type": "number"},
+    "NUMERIC": {"type": "number"},
+    # booleans
+    "BOOLEAN": {"type": "boolean"},
+    "BOOL": {"type": "boolean"},
+    # date-time
+    "TIMESTAMP WITH TIME ZONE": {
+        "type": "string",
+        "format": "date-time",
+    },
+    "TIMESTAMP": {"type": "string", "format": "date-time"},
+    "DATE": {"type": "string", "format": "date"},
+    # arrays → just mark as array; avoid full recursion for compound types
+}
+
+
+def _duckdb_type_to_jsonschema(duckdb_type: str) -> dict[str, Any]:
+    """Convert a DuckDB column type string to a JSON-Schema fragment."""
+    upper = duckdb_type.upper().strip()
+
+    # Geometry columns – treat as GeoJSON geometry object
+    if upper.startswith("GEOMETRY"):
+        return {
+            "type": "object",
+            "title": "GeoJSON Geometry",
+            "format": "geojson-geometry",
+        }
+
+    # Array types: e.g. "VARCHAR[]", "BIGINT[]"
+    if upper.endswith("[]"):
+        item_schema = _duckdb_type_to_jsonschema(upper[:-2])
+        return {"type": "array", "items": item_schema}
+
+    # STRUCT – represent as JSON object (too complex to unroll inline)
+    if upper.startswith("STRUCT"):
+        return {"type": "object"}
+
+    # MAP types
+    if upper.startswith("MAP"):
+        return {"type": "object"}
+
+    # Exact match
+    if upper in _DUCKDB_TO_JSONSCHEMA:
+        return dict(_DUCKDB_TO_JSONSCHEMA[upper])
+
+    # Prefix match (e.g. DECIMAL(10,2), NUMERIC(5))
+    for prefix, schema in _DUCKDB_TO_JSONSCHEMA.items():
+        if upper.startswith(prefix):
+            return dict(schema)
+
+    # Fallback
+    return {}
+
+
+# Fields that are standard STAC properties always present
+_STAC_CORE_QUERYABLES: dict[str, dict[str, Any]] = {
+    "id": {
+        "title": "Item ID",
+        "description": "Provider identifier for the Item.",
+        "type": "string",
+    },
+    "collection": {
+        "title": "Collection",
+        "description": "The ID of the collection this Item belongs to.",
+        "type": "string",
+    },
+    "datetime": {
+        "title": "Datetime",
+        "description": "Datetime associated with this Item.",
+        "type": "string",
+        "format": "date-time",
+    },
+    "geometry": {
+        "title": "Item Geometry",
+        "description": "Spatial extent of this Item.",
+        "type": "object",
+        "format": "geojson-geometry",
+    },
+}
+
+# Columns that are internal implementation details, not useful as queryables
+_SKIP_COLUMNS: frozenset[str] = frozenset(
+    {
+        "type",
+        "stac_version",
+        "stac_extensions",
+        "links",
+        "assets",
+        "providers",
+        "bbox",
+        "geometry",  # re-added via _STAC_CORE_QUERYABLES with a nicer description
+    }
+)
+
+
+def _extract_queryable_properties(
+    describe_rows: list[tuple[Any, ...]],
+    skip_columns: frozenset[str],
+    known_queryables: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Turn DESCRIBE output rows into a JSON-Schema *properties* dict."""
+    properties: dict[str, dict[str, Any]] = {}
+
+    for row in describe_rows:
+        col_name: str = row[0]
+        col_type: str = row[1]
+
+        if col_name in skip_columns:
+            continue
+
+        schema_fragment = _duckdb_type_to_jsonschema(col_type)
+        if col_name in known_queryables:
+            # Prefer the curated title/description over anything inferred
+            # from the DuckDB column type.
+            schema_fragment = known_queryables[col_name].copy()
+        else:
+            # Use title-cased column name as a human-readable title
+            schema_fragment["title"] = (
+                col_name.replace(":", ": ").replace("_", " ").title()
+            )
+
+        properties[col_name] = schema_fragment
+
+    return properties
+
+
+class FiltersClient(BaseFiltersClient):
+    """filter client using rustac
+
+    When `collection_id` is *None* (i.e. the global ``/queryables``
+    endpoint) returns static common queryables
+
+    Subclasses can extend :attr:`known_queryables` with curated
+    titles/descriptions for their own properties, and add internal columns to
+    :attr:`skip_columns` to keep them out of the queryables document.
+    """
+
+    known_queryables: dict[str, dict[str, Any]] = _STAC_CORE_QUERYABLES
+    skip_columns: frozenset[str] = _SKIP_COLUMNS
+
+    def get_queryables(
+        self,
+        collection_id: str | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        request: Request = kwargs["request"]
+
+        hrefs: dict[str, str] = request.state.hrefs
+        collections: dict[str, Any] = request.state.collections
+
+        base_url = str(request.base_url).rstrip("/")
+
+        if collection_id is not None:
+            # Single-collection queryables
+            if collection_id not in collections:
+                raise NotFoundError(f"Collection does not exist: {collection_id}")
+
+            href = hrefs.get(collection_id)
+            if href is None:
+                # Collection exists but has no geoparquet backing – return core only
+                return _build_queryables_doc(
+                    collection_id=collection_id,
+                    base_url=base_url,
+                    properties=dict(self.known_queryables),
+                )
+
+            properties = self._properties_for_href(href, request)
+            return _build_queryables_doc(
+                collection_id=collection_id,
+                base_url=base_url,
+                properties=properties,
+            )
+
+        else:
+            # Global /queryables – return only the STAC core properties. The Filter
+            # spec explicitly allows this; clients that need collection-specific
+            # properties should query /collections/{id}/queryables instead.
+            return _build_queryables_doc(
+                collection_id=None,
+                base_url=base_url,
+                properties=dict(self.known_queryables),
+            )
+
+    def _properties_for_href(
+        self,
+        href: str,
+        request: Request,
+    ) -> dict[str, dict[str, Any]]:
+        """Run DESCRIBE on the parquet file and return queryable properties."""
+        client = cast(DuckdbClient, request.state.client)
+        try:
+            safe_href = href.replace("'", "''")
+            arrow_table = client.query_to_table(
+                f"DESCRIBE SELECT * FROM read_parquet('{safe_href}') LIMIT 0"
+            )
+
+            # Convert these columns from the Arrow Table to Python lists.
+            column_names = arrow_table.column("column_name").to_pylist()
+            column_types = arrow_table.column("column_type").to_pylist()
+
+            # Zip the lists together
+            rows = list(zip(column_names, column_types))
+
+            return _extract_queryable_properties(
+                rows, self.skip_columns, self.known_queryables
+            )
+        except Exception:
+            # If schema introspection fails fall back to the STAC core queryables
+            return dict(self.known_queryables)
+
+
+def _build_queryables_doc(
+    *,
+    collection_id: str | None,
+    base_url: str,
+    properties: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Return a conformant OGC-API / STAC-API Queryables JSON-Schema document."""
+    if collection_id is not None:
+        doc_id = f"{base_url}/collections/{collection_id}/queryables"
+        title = f"Queryables for {collection_id}"
+        description = (
+            "Filterable properties available for items in collection "
+            f"'{collection_id}'."
+        )
+    else:
+        doc_id = f"{base_url}/queryables"
+        title = "Global Queryables"
+        description = (
+            "Filterable properties available across all collections in this STAC API."
+        )
+
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": doc_id,
+        "type": "object",
+        "title": title,
+        "description": description,
+        "properties": properties,
+    }

--- a/src/stac_fastapi/geoparquet/models.py
+++ b/src/stac_fastapi/geoparquet/models.py
@@ -1,17 +1,35 @@
 import stac_fastapi.api.models
 from stac_fastapi.api.models import ItemCollectionUri
-from stac_fastapi.extensions.core.fields import FieldsExtension
-from stac_fastapi.extensions.core.filter import SearchFilterExtension
+from stac_fastapi.extensions.core.fields import (
+    FieldsConformanceClasses,
+    FieldsExtension,
+)
+from stac_fastapi.extensions.core.filter import (
+    FilterConformanceClasses,
+    FilterExtension,
+)
 from stac_fastapi.extensions.core.pagination import OffsetPaginationExtension
 from stac_fastapi.extensions.core.sort import SortExtension
 from stac_fastapi.types.search import BaseSearchPostRequest
 
+from .filters import FiltersClient
 from .search import FixedSearchGetRequest
+
+# The full Filter extension, rather than the search-only one: it registers
+# `/queryables` and `/collections/{collection_id}/queryables` alongside the
+# `filter` search parameter.
+filter_extension = FilterExtension(client=FiltersClient())
+filter_extension.conformance_classes.append(
+    FilterConformanceClasses.ADVANCED_COMPARISON_OPERATORS
+)
+# `fields` works on the items endpoint too, not just search.
+fields_extension = FieldsExtension()
+fields_extension.conformance_classes.append(FieldsConformanceClasses.ITEMS)
 
 EXTENSIONS = [
     OffsetPaginationExtension(),
-    SearchFilterExtension(),
-    FieldsExtension(),
+    filter_extension,
+    fields_extension,
     SortExtension(),
 ]
 

--- a/src/stac_fastapi/geoparquet/schema.py
+++ b/src/stac_fastapi/geoparquet/schema.py
@@ -1,0 +1,50 @@
+"""Reading a geoparquet file's column schema."""
+
+from typing import Any, cast
+
+from rustac import DuckdbClient
+
+# Columns that are structural STAC members rather than searchable metadata.
+STRUCTURAL_COLUMNS: frozenset[str] = frozenset(
+    {
+        "type",
+        "stac_version",
+        "stac_extensions",
+        "links",
+        "assets",
+        "providers",
+        "bbox",
+        "geometry",
+    }
+)
+
+_TEXT_TYPES: frozenset[str] = frozenset({"VARCHAR", "TEXT", "STRING", "CHAR", "BPCHAR"})
+
+
+def describe_columns(client: DuckdbClient, href: str) -> list[tuple[str, str]]:
+    """Return ``(name, duckdb type)`` for every column in a geoparquet file.
+
+    Raises whatever DuckDB raises if the file can't be read; callers decide
+    whether an unreadable file is fatal.
+    """
+    safe_href = href.replace("'", "''")
+    table = client.query_to_table(
+        f"DESCRIBE SELECT * FROM read_parquet('{safe_href}') LIMIT 0"
+    )
+    names = cast(list[str], table.column("column_name").to_pylist())
+    types = cast(list[str], table.column("column_type").to_pylist())
+    return list(zip(names, types))
+
+
+def text_columns(columns: list[tuple[str, Any]]) -> list[str]:
+    """Pick the plain-text columns worth searching from a DESCRIBE result.
+
+    Structural members are dropped: matching every item because its `type` is
+    "Feature" is not what a free-text search means.
+    """
+    return [
+        name
+        for name, column_type in columns
+        if name not in STRUCTURAL_COLUMNS
+        and str(column_type).upper().strip() in _TEXT_TYPES
+    ]

--- a/tests/test_queryables.py
+++ b/tests/test_queryables.py
@@ -1,0 +1,34 @@
+"""Tests for the Filter extension's queryables endpoints."""
+
+from fastapi.testclient import TestClient
+
+
+def test_global_queryables(client: TestClient) -> None:
+    response = client.get("/queryables")
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert data["$id"].endswith("/queryables")
+    assert data["type"] == "object"
+    for core in ("id", "collection", "datetime", "geometry"):
+        assert core in data["properties"], core
+
+
+def test_collection_queryables(client: TestClient) -> None:
+    response = client.get("/collections/naip/queryables")
+    assert response.status_code == 200, response.text
+    data = response.json()
+    properties = data["properties"]
+    # Schema-derived, collection-specific property
+    assert "naip:year" in properties
+    assert properties["naip:year"]["type"] == "string"
+    # Core STAC properties keep their curated schemas
+    assert properties["datetime"]["format"] == "date-time"
+    # Structural members must not be advertised as queryable
+    assert "assets" not in properties
+    assert "links" not in properties
+
+
+def test_collection_queryables_unknown_collection(client: TestClient) -> None:
+    response = client.get("/collections/not-a-collection/queryables")
+    assert response.status_code == 404

--- a/uv.lock
+++ b/uv.lock
@@ -34,6 +34,59 @@ wheels = [
 ]
 
 [[package]]
+name = "arro3-core"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/68/db11c4ad146cc6625b68c3e33e4370de759950babbaac5b74a41164c91f9/arro3_core-0.8.2.tar.gz", hash = "sha256:51eac10b2113623a452b44480844a4edbd17bfc83f4545b56e1240636b7c2334", size = 92831, upload-time = "2026-09-03T08:03:30.386Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/fa/733457381266baa8ccd9dc916dcfee712d28d654be288c9a361cb77d2ad0/arro3_core-0.8.2-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f11104bccd3a6f210f8c1cf4d182ad8aaeca0f82f62c39a3b2f8f21c63b32cb3", size = 2998398, upload-time = "2026-09-03T08:01:58.841Z" },
+    { url = "https://files.pythonhosted.org/packages/28/30/cb2a2d09ee2829dd6aa16fb6df93729fe17d8ee4c01d56dfa87fa8c07a7d/arro3_core-0.8.2-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:c440eb44ab78397a783e4429490102967008a8b2383bd0f70433f4594689a7ee", size = 2754039, upload-time = "2026-09-03T08:02:00.559Z" },
+    { url = "https://files.pythonhosted.org/packages/82/27/384014251ac0d3f5c5b76ce816355dba2223e29564fab8d80b25f5462863/arro3_core-0.8.2-cp311-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6c48f9f2230f0869982021e7b92794456ffca99320565b7519fecd770e798cba", size = 3223780, upload-time = "2026-09-03T08:02:02.173Z" },
+    { url = "https://files.pythonhosted.org/packages/95/3c/e6dc5ae989d000159fed1172378efc9e8c49c17a9f52b1e724da507483e4/arro3_core-0.8.2-cp311-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6fbc60e277021b4d78dce1adaa2988040cbfb7ddf358ee5fa66ae30a96f3b184", size = 3335234, upload-time = "2026-09-03T08:02:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/38/d3/0b10a3e4617094494df3243f71092b5a210da0d3773d813ca2d5068fb763/arro3_core-0.8.2-cp311-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f51a5924a6503360cbc679015e1df88ce2515a3dd2cae3cf52c076f84be255ed", size = 3476780, upload-time = "2026-09-03T08:02:06.069Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/13/2adc42096a1b165064cabf17515e6cc7aa5490e71c3e570ff579f921e09f/arro3_core-0.8.2-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c5b361bf1a483536047bbf22568baeae66d72bb2c265d2ac4d45ef51f23c921", size = 3139773, upload-time = "2026-09-03T08:02:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/f4/b80b73004a713de878b0ee0348154db78b3c32f5156240035670d8811fa1/arro3_core-0.8.2-cp311-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:f0bcfddba1a461dc2b2edbbd814642c22492dfc2476d69efa3ab65dcdbfb6b9c", size = 2908405, upload-time = "2026-09-03T08:02:09.082Z" },
+    { url = "https://files.pythonhosted.org/packages/76/43/cf253c6fc47202cfc899b2d115265c28e2dc7873e03fa27324a0b3a2355f/arro3_core-0.8.2-cp311-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2618873ff8dd2d5141978cb43b5fe1ef095981ba957c456df680664e6d22c130", size = 3372617, upload-time = "2026-09-03T08:02:10.477Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/6c/987d09b09afe515af67a3523325ff1ba111b16cebb3c81deeca794dcc30a/arro3_core-0.8.2-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fbf5b07ebba94ea5fab381c9366217f78152705222a94ae00c97360333d9305d", size = 3088499, upload-time = "2026-09-03T08:02:12.042Z" },
+    { url = "https://files.pythonhosted.org/packages/83/85/b6189b91ef1a25c9208cbbe58cacc42293c84309eb7fd2deaca02870a68a/arro3_core-0.8.2-cp311-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:0ef906334704039f78d25c1beab653e3ec46ed14c8583f7c1e4e24d0a8f28b8d", size = 3502723, upload-time = "2026-09-03T08:02:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/d7/ae3bd97c2ebc9a79508c6789dcba9bfacd87d59ce67ee519b9651e2e808a/arro3_core-0.8.2-cp311-abi3-musllinux_1_2_i686.whl", hash = "sha256:836e32d604cdcad0e1943bbeeebcb5ae8211e19e661071358ea5a8443b8ae854", size = 3474134, upload-time = "2026-09-03T08:02:15.188Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/32/0d5e4b03b9564a7c58726c5b2b9591952a13cf5c84716adccb7669f88a1c/arro3_core-0.8.2-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b74963ca517a940632020a04f3613321d7bb198c9ed2e193590d27c592ae9853", size = 3359886, upload-time = "2026-09-03T08:02:16.731Z" },
+    { url = "https://files.pythonhosted.org/packages/24/5a/85edfa131fe52bcb33c9c9e9eab10dec197f039a74e05121d30784a205cd/arro3_core-0.8.2-cp311-abi3-win_amd64.whl", hash = "sha256:195d1003303e050da262b0727d107a2aa7271216f60283fff925612dd7d45c95", size = 3311607, upload-time = "2026-09-03T08:02:18.337Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/18/73fe6503a3a657a6ccde27d4917e95a52525adc19f981b978b208675d579/arro3_core-0.8.2-cp311-abi3-win_arm64.whl", hash = "sha256:6a57975132c3ee967be1c2a8dd3950ac17990a38b9774f671b78c66395e6d90f", size = 2961638, upload-time = "2026-09-03T08:02:20.158Z" },
+    { url = "https://files.pythonhosted.org/packages/25/0e/e487d2ea877073f140753445f0033145ab3c60ed3fe5445533cb6a34e84a/arro3_core-0.8.2-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:ed4c2a8d0deaf1da3ac497d0b97f3fd236ca531200c4ce23ec2649cec47da1dc", size = 1718880, upload-time = "2026-09-03T08:02:21.942Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/42/598184778b594bda7b2aed4b23908ddfd305138ef0934a0adedf5b2a7b25/arro3_core-0.8.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:a46bada55d9f6678d4738cef8169082c0d13ca495ec2a7b10b7956739a03fb6c", size = 1703773, upload-time = "2026-09-03T08:02:23.362Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/ec71aa5f59563e35f42047dfa38a1e2a52e96d0c32a4df02347bce7cb313/arro3_core-0.8.2-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:cecfeeb5c8a4468b00d15be84ee57d125bd888fd590051e290dd9a1003522495", size = 3017388, upload-time = "2026-09-03T08:02:24.722Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/e6/4c5293c663c7255cf69ee261c3cf951dd92ca3f9ec8a89bf9f58a9c8854c/arro3_core-0.8.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:508efa269e5a93a39c9fc2d624815aeebda446aa04388ac5b22dbf74d0d2a106", size = 2737056, upload-time = "2026-09-03T08:02:26.179Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/8a9dcaffac07c1fc9f76f2d1a5d458c40320323fdc0f6e74692da403a6a7/arro3_core-0.8.2-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:171b427c79058cf3ec6758794bafca2affaca061cecb07a0930f72e1460874cc", size = 3219201, upload-time = "2026-09-03T08:02:28.232Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/9a/3b273599a13ff8e8f92f560204b3335b2fe446480eda2709bebd7b3a4f7d/arro3_core-0.8.2-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:974245b76afa20528fdde6a57aa88efa22cfe27effab0580f198877bc0fb56fc", size = 3321140, upload-time = "2026-09-03T08:02:29.818Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/ce/8ac97dddd64bfbb188205f1869ea9eb6d0c2cd2bbad744ae3e65f336934c/arro3_core-0.8.2-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:22daff2943c803eb888b94036eeeb20ce9ddca649dfbbeb30c470ca4bf70e65b", size = 3481157, upload-time = "2026-09-03T08:02:31.438Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/03/1667805eaa865287f3c6480e22d3747bb92d46954048327a6934b906edfc/arro3_core-0.8.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:858fe80ebec6fb172ce760979bc51d15f370f0cd11f50db61e2516912eb244c8", size = 3132210, upload-time = "2026-09-03T08:02:32.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/0f/7e4b90f0b15898ceb09fe7a81818d33143daaf512f20077a0ccee365335d/arro3_core-0.8.2-cp314-cp314t-manylinux_2_24_aarch64.whl", hash = "sha256:955428a268b44e6cb1be18bc69ad4cc4d114e8a4db87aacb9f6b216ddf7c5762", size = 2902939, upload-time = "2026-09-03T08:02:34.444Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b9/7fc0e89aa6640183ea368c27f53255aea111290eed91f0e2c66527e8e7bc/arro3_core-0.8.2-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:216deb890962ce29ad03c612c2d952109f3f33b242435a645529c41115045b34", size = 3358896, upload-time = "2026-09-03T08:02:35.987Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/90/13bffa1518126597add8ab6ab32356ab69614f74392feeb303edfab306a3/arro3_core-0.8.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0bb9b3d5fdbb1f003de38c1de6c92a1e01494396e24d1ff89dd50c6e9e97f896", size = 3082548, upload-time = "2026-09-03T08:02:37.474Z" },
+    { url = "https://files.pythonhosted.org/packages/39/a6/92124aeea9b1268db7cf72b2ca37983774719cd6e2f4e7929db2073cfda5/arro3_core-0.8.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:866eeab0b4f9914b3c24afdee0d511f3e676698640f8c4edec3f0bf2f9dd1cbc", size = 3498273, upload-time = "2026-09-03T08:02:41.343Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/40/a89f5769487815ac84a082d502a207e0a8b43b3b78701564770b079e3dbd/arro3_core-0.8.2-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:ad3697ad4b5e3dcf12374a640348b76bdb31b32ffe623d3946fb201e2560f085", size = 3460783, upload-time = "2026-09-03T08:02:42.859Z" },
+    { url = "https://files.pythonhosted.org/packages/50/8c/d1e9747751ad34d0c5c91ec1b02474a44c9ab903e1a38f0e64490ac80403/arro3_core-0.8.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:fae5254eede746f18c575d8a8baff2da0dda15c43d10f9e099a5e46ba1c2a743", size = 3352750, upload-time = "2026-09-03T08:02:44.322Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fc/1e8d55efd0ff7b34a489132968a7508485dbfce96f632c76f48cb65368b5/arro3_core-0.8.2-cp314-cp314t-win_amd64.whl", hash = "sha256:7edc7ea86012638f5cd7d147b0155addd81255bbcbf5c6b1c2bd2643d523aa1f", size = 3290376, upload-time = "2026-09-03T08:02:45.927Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/2e/806752270276a9ccb3b9fdc16d3b64a7f551ddea9f3a42c00cb935691716/arro3_core-0.8.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f7bebb1f6630f203bd38e887db77d2780efd54ba3aadf2400b550c1660946cb2", size = 2944973, upload-time = "2026-09-03T08:02:47.681Z" },
+    { url = "https://files.pythonhosted.org/packages/77/7b/cc993ad965f42730a7b860613ed8c0b9ee6b0338aaa18163034bf4189b01/arro3_core-0.8.2-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:badb423ddec4885a094cf8c1a602e6f4282488c965c879ce7c14dc44eeaba28c", size = 3006013, upload-time = "2026-09-03T08:03:10.585Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/7c/237a2a0f271efde47aa4220747d912dc2ab980c405cb3f1f3c15cd668a33/arro3_core-0.8.2-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b6dea61d6507a37df1b9ea748ce1da77952703f5b3e310b9395917da2c9e3dc9", size = 2761746, upload-time = "2026-09-03T08:03:12.361Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/f2/b5ce96a781b0b576d39f389ede306907ff3d1333972cfbfadc45d56a3a9e/arro3_core-0.8.2-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f6f6fc755b220988c34acb1d76c0edc2568cd494d46f995bc0b7500365716795", size = 3236090, upload-time = "2026-09-03T08:03:13.818Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/96/b5984de2dac0cfa566e6d5671cf8818540b72d92fb5b4865e89f392963c7/arro3_core-0.8.2-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b9c392ebf9eacb5be13b93bd2313b1bf31185ce3598d61c24470df13ca9787df", size = 3344054, upload-time = "2026-09-03T08:03:15.546Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/6f/5d03d8b577f61826d8ff53ef9ff030e7594d45f603c3476e7d68c5b94f19/arro3_core-0.8.2-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:884f7b0a76f569681fb3433dafdaa84dbc8312fd235e76038982356d4365810e", size = 3486323, upload-time = "2026-09-03T08:03:17.077Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2c/7bde04fbdb48297c132c0db642ef94266d4b6fe4fc12cefb0017d8b8c660/arro3_core-0.8.2-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e80539b662c1ac48397de96cb8a9f6716bd6be04f5fef53c826b5d0507ed587", size = 3145312, upload-time = "2026-09-03T08:03:19.078Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2a/c6363c58fda54d5ecaddedd51a2f297eafe3e6854a4b2b7e233cfe4776c3/arro3_core-0.8.2-pp311-pypy311_pp73-manylinux_2_24_aarch64.whl", hash = "sha256:6544470e24831cb62d976358706db35d3b0c44b537775b3bc339e9eea3b4fe80", size = 2922585, upload-time = "2026-09-03T08:03:20.839Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/6d/cd96d0318b681e63fb6470fdadd8ca7be26669ab062e1370c8c5dd03e147/arro3_core-0.8.2-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:54a3e98a9bd158d454b79dae35b3bff47d66d5f991041e14598fe0bc2b8e1a2b", size = 3378312, upload-time = "2026-09-03T08:03:22.315Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/72/c0c32ef940ddcb35802d197e66b2f2dd8c3aa99072c871921a964c9b71fa/arro3_core-0.8.2-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:5c60a064c650dea38b4bc34dea8a0c578de96dd0197efe036c06792d93b7be56", size = 3100387, upload-time = "2026-09-03T08:03:23.868Z" },
+    { url = "https://files.pythonhosted.org/packages/50/12/4e7b8b59f24e14f3fff0b7f1b8148fdcc127c2d1bd0673830f117b252a57/arro3_core-0.8.2-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:61fc6088959f9918c8d780363aefb1f77ea8c34a24340c8ec657cdec1c53c53d", size = 3514801, upload-time = "2026-09-03T08:03:25.691Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/52/c08379366238eaabf2c352af1ed6f752794518996321c9291abe99d57291/arro3_core-0.8.2-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:5f484bc74703493d9af0f7ecab204962259023ee99fff485f49a76496b91bed4", size = 3482578, upload-time = "2026-09-03T08:03:27.418Z" },
+    { url = "https://files.pythonhosted.org/packages/89/9d/4d37156d136bf82d36089cf9d037fe47dcaccf6f997c763f7de283210dbd/arro3_core-0.8.2-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:fe4c8826f2fad626377440f43ac14378de45b09be049c26d00f102d1b53637b3", size = 3367140, upload-time = "2026-09-03T08:03:28.989Z" },
+]
+
+[[package]]
 name = "attr"
 version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -791,14 +844,14 @@ wheels = [
 
 [[package]]
 name = "mangum"
-version = "0.21.0"
+version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/cb/d9f4d685a0b8eceac10991e15ac471d9568e4e42c2489ae9bf072828c1c2/mangum-0.21.0.tar.gz", hash = "sha256:e31ed72d67f9958fa4379f65df77729906dec6dfa00afa6ed4e06c77833000de", size = 89130, upload-time = "2026-02-01T17:17:42.816Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/c8/1579c705908d02a4526a748e8d0f0419151d4498c59033840f5df3a14822/mangum-0.22.0.tar.gz", hash = "sha256:701936891aaed8ed66479b871c2bda87ba288fd01c7d5dd6ba6c8e9ba1c239d1", size = 118290, upload-time = "2026-08-22T12:54:48.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/50/e3c694b8e122551e4557450219283771334dee2ed5734a8398c8b8018c50/mangum-0.21.0-py3-none-any.whl", hash = "sha256:309e48f5c629542516c5106ecf079f4ec08809ed50df882238d98fe1392820c7", size = 17146, upload-time = "2026-02-01T17:17:41.553Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a2/21ee5d457ae79a2587ff0d4652990670b7cac84ba0eaab6e6865a3bd2515/mangum-0.22.0-py3-none-any.whl", hash = "sha256:a0595e3cc7a8091b22d8b3997bab5b2ad6aae7a5e40865e19c2015f5c959a93b", size = 17143, upload-time = "2026-08-22T12:54:46.924Z" },
 ]
 
 [[package]]
@@ -1925,20 +1978,22 @@ wheels = [
 
 [[package]]
 name = "rustac"
-version = "0.9.3"
+version = "0.9.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b1/dc/0c0618f576119fe1ac7b5b03a968a4a825411b0460f748039210e98c1dcd/rustac-0.9.3.tar.gz", hash = "sha256:427dc5325617d6c57f504318bc9f703763dc40df66d35a888d407d0ebc0f8c9f", size = 737820, upload-time = "2026-01-06T12:50:32.929Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/00/dfd09a5eb0681af8ed8136d52eb6056def889df33ef1db530419d0d33e1a/rustac-0.9.17.tar.gz", hash = "sha256:fd65e922e52f277d38f500f3e43fb7c76ea7ffb5d1209bc29a74a5c4754caf4d", size = 460116, upload-time = "2026-08-18T13:58:08.054Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/ef/d9698e162ffcbc47f172162d8f37a82f56c8afb7e3d48d10583952c6c29a/rustac-0.9.3-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d3cc8bed80370b54450377a53ebc33980ae59ec4e5fc37aea01ff29dc9133400", size = 25960779, upload-time = "2026-01-06T12:50:19.666Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/62/6bebac90e854f008cf4b5788698d8c568fa4184fd77cb3b3f9f45cdac546/rustac-0.9.3-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:2f9cf5f1fe536bd88c1fe2ac26d9d22a55e5143ac76a8af6b1ee8534b99dd9b7", size = 24090602, upload-time = "2026-01-06T12:50:17.183Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/2f/07edacb1b1a82b08cdaf5691442076f5852e40979859b116eae8802acbc3/rustac-0.9.3-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e1f6f94eaf0fd93d5f5f0687b73b43a9ada0e176eb6b4c8d279829892ccf9109", size = 28102224, upload-time = "2026-01-06T12:50:05.228Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/46/555e3fefe7f5775885e0d3765f10e035d0e540cc4253a493f29fda9da14b/rustac-0.9.3-cp311-abi3-manylinux_2_28_armv7l.whl", hash = "sha256:be326379c3e2599e1e02e02ff2c56fc3b324a9afd30bed1f0abfb03b33f3e6d1", size = 26388084, upload-time = "2026-01-06T12:50:08.089Z" },
-    { url = "https://files.pythonhosted.org/packages/82/1e/1c6e8ab14ef6066991232e9338ae42cb824376d22291e3d3c9741274eaca/rustac-0.9.3-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:288216ca0f96136afb8422e24728e19be535e6e34192b25763bfc374c98d72a9", size = 34572191, upload-time = "2026-01-06T12:50:10.682Z" },
-    { url = "https://files.pythonhosted.org/packages/46/0f/e41b599cd4f81e62b14b06b5c45b68ea52fb644f9e99d7791df5bd55bfc7/rustac-0.9.3-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:df941bdbaedaf6bf0b51976c923642c9bab55ed5a8e25a56bc49b02a11887f28", size = 31255045, upload-time = "2026-01-06T12:50:13.232Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/08/479539289c0e0de5095a8fd42308aa0669c3413f7590c5907137fd1a1f48/rustac-0.9.3-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:8e8355fa226d109be2be7aed485034eb69851fb6b59a9ed47af9379356b75825", size = 34678348, upload-time = "2026-01-06T12:50:22.632Z" },
-    { url = "https://files.pythonhosted.org/packages/14/19/53c5cbb4b7daa46abbb4f3db01f9fba619b73c20600eab9fc10ddcaed19b/rustac-0.9.3-cp311-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1a02d268580e7c6595563a2c3b3c8f12ee15411071ebcbd09f61f0325b64d46e", size = 34008454, upload-time = "2026-01-06T12:50:25.328Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/28/6606216351812a1bd9043dd6284216b3065af0a0f3d7deb00333ad4561db/rustac-0.9.3-cp311-abi3-musllinux_1_2_i686.whl", hash = "sha256:4b162fc0051dd440deb1bdfa4a9d3ea6726d0b3355f11c630a7528780178679a", size = 39073017, upload-time = "2026-01-06T12:50:27.863Z" },
-    { url = "https://files.pythonhosted.org/packages/56/7e/e3390934aa0a85fb7044fe8ca9c53868b55c0c2e996236e074b7c51ff429/rustac-0.9.3-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d3f3bb74f49acfbbce42be113dab300e98226b763974f7bbe94835bb90e7dcd6", size = 37084098, upload-time = "2026-01-06T12:50:30.696Z" },
+    { url = "https://files.pythonhosted.org/packages/80/76/7eaa45d16c8b17d520a665bc80566288dcb57ca5dc848bd168378f8d2d75/rustac-0.9.17-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f3e1885d44497bc553405343a69ac21cb9371311dae1ae63349a520d006d5e25", size = 28875390, upload-time = "2026-08-18T13:57:51.594Z" },
+    { url = "https://files.pythonhosted.org/packages/de/86/cae59c7628b2d6a0caa400280815054d3b4264d6b9602234dd056129280e/rustac-0.9.17-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:3bda15586db94be086bf492ddec17c5c1bac3dc5fd603076edea6c8ae4436332", size = 27071209, upload-time = "2026-08-18T13:57:48.58Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/c0/bd29ef33f5bb95bb9e442d4745d8cb89e0a0739a219f9f556d9ddce87484/rustac-0.9.17-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f14ed91cd7c2a879d97bea589bd5a69768075bd80d69a348bd4e0ed8deed55f0", size = 28878090, upload-time = "2026-08-18T13:57:36.081Z" },
+    { url = "https://files.pythonhosted.org/packages/99/b2/a09273d5d3a27377ef11153e98b1713647a381eacfd70124f80303ed7055/rustac-0.9.17-cp311-abi3-manylinux_2_28_armv7l.whl", hash = "sha256:cb4de4fe181b78bd9aa2834a6bd6460fc01c1fc800b0c681a87fb357004511e7", size = 27687729, upload-time = "2026-08-18T13:57:38.753Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/df/2941858d190d4a8fa63fad9a67e3d627bfb88716d79dea310af94af3c4e7/rustac-0.9.17-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:8ca0627cf58da1ba0be43b5be70a66abeea1172212d8062969f0d03a9aba95a4", size = 35798474, upload-time = "2026-08-18T13:57:41.8Z" },
+    { url = "https://files.pythonhosted.org/packages/80/44/799f69cfc09deca638fd08a3f58cb4405a6b9b76f3add121908b66f31325/rustac-0.9.17-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:d4846bda2f150e73e3600c8a19ff9d013b11714aaf90fd3494eb4429bf6928a7", size = 32418950, upload-time = "2026-08-18T13:57:45.419Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/74/fd4c252d52f3ba0e5e1beb2f9dd5665cd4c1903ff5c072c9e3ef126df5b3/rustac-0.9.17-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:72fa6c9096a1850c5e07f546954e345f7d5a79aa39386e5dd7563c32405af8df", size = 35423299, upload-time = "2026-08-18T13:57:54.754Z" },
+    { url = "https://files.pythonhosted.org/packages/41/7d/2980696da86613b8fe65a0c8505dca2a3e99ef27e23fcd304705d1e63a16/rustac-0.9.17-cp311-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c9cc83d9bc1380900b91f7a2841f21a22067acad3039c03b94574947f28dd680", size = 35431561, upload-time = "2026-08-18T13:57:59.067Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/84/cbec9a7a89413c5d181011ad5117dfdf728abd1011ec8ca82abb4edbaf45/rustac-0.9.17-cp311-abi3-musllinux_1_2_i686.whl", hash = "sha256:57a687f2d80e2218d907cf5b17a34dd8663c9128fa8f6f3123fd61ed7d3f9475", size = 40511950, upload-time = "2026-08-18T13:58:02.025Z" },
+    { url = "https://files.pythonhosted.org/packages/65/c0/2ae4c215202c2941ba7c40da9027cf34f0569760dbe2d59f1225912e4352/rustac-0.9.17-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:bd60f7551100eef0ddf3d6f138a2f1049c757ecd375a88001846e7d1e76644b2", size = 38179384, upload-time = "2026-08-18T13:58:05.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/f6/7080228e61fc85efdf60c4753ddde267afe2947080359e37a4a6075ab2aa/rustac-0.9.17-cp311-abi3-win32.whl", hash = "sha256:0eccaedcdf133c6318f8b8ab7e4af63184a9a8369b6259e8529119c3e6043c1c", size = 24582067, upload-time = "2026-08-18T13:58:13.077Z" },
+    { url = "https://files.pythonhosted.org/packages/75/4b/020856cd4f2ce85cc7077f5e84805f50307094196def58be6b462a440a63/rustac-0.9.17-cp311-abi3-win_amd64.whl", hash = "sha256:499599ff2f6f54fac5dbc025b98e764a04588e9b153baae2affc1cd68ec0cb30", size = 27465525, upload-time = "2026-08-18T13:58:09.78Z" },
 ]
 
 [[package]]
@@ -2099,9 +2154,10 @@ wheels = [
 
 [[package]]
 name = "stac-fastapi-geoparquet"
-version = "0.0.5"
+version = "0.0.6"
 source = { editable = "." }
 dependencies = [
+    { name = "arro3-core" },
     { name = "attr" },
     { name = "fastapi" },
     { name = "geojson-pydantic" },
@@ -2145,14 +2201,15 @@ validate = [
 
 [package.metadata]
 requires-dist = [
+    { name = "arro3-core", specifier = ">=0.8.0" },
     { name = "attr", specifier = ">=0.3.2" },
     { name = "fastapi", specifier = ">=0.115.8" },
     { name = "geojson-pydantic", specifier = ">=1.2.0" },
-    { name = "mangum", marker = "extra == 'lambda'", specifier = "==0.21.0" },
+    { name = "mangum", marker = "extra == 'lambda'", specifier = "==0.22.0" },
     { name = "obstore", specifier = ">=0.8.0" },
     { name = "pydantic", specifier = ">=2.10.4" },
     { name = "pystac", specifier = ">=1.13.0" },
-    { name = "rustac", specifier = ">=0.7.0" },
+    { name = "rustac", specifier = ">=0.9.11" },
     { name = "stac-fastapi-api", specifier = ">=5.0.2" },
     { name = "stac-fastapi-extensions", specifier = ">=5.0.2" },
     { name = "stac-fastapi-types", specifier = ">=5.0.2" },


### PR DESCRIPTION
Serves `/queryables` and `/collections/{collection_id}/queryables` by swapping the search-only Filter extension for the full one and giving it a client backed by the geoparquet schema: a `DESCRIBE` on the collection's file maps each column to a JSON Schema fragment, with curated titles for the STAC core properties and structural members (`links`, `assets`, `bbox`, …) left out.

The global endpoint returns only the core properties. The Filter spec allows that, and the alternative — unioning every collection's schema — describes a document shape that no single collection actually has.

Collections now carry a queryables link, so the endpoint is discoverable rather than something a client has to know to construct.

Also advertises the advanced comparison operators (`LIKE`, `BETWEEN`, `IN`), which the backend already supports, and the Fields extension on the items endpoint.

### Dependencies

`DuckdbClient.query_to_table` returns an arro3 table, so this adds `arro3-core` and moves the rustac floor to `>=0.9.11` for that method. (The lockfile diff also picks up an existing drift between `pyproject.toml` and `uv.lock` on `main` — mangum 0.21 vs 0.22.)

### Note on overlap

`src/stac_fastapi/geoparquet/schema.py` is also added by the free-text search PR, with identical content. Whichever merges first, the other rebases cleanly.

### Verification

`scripts/lint` and `scripts/test` pass.
