### PR TITLE
feat: support collection search on /collections

### DIFF
--- a/src/stac_fastapi/geoparquet/api.py
+++ b/src/stac_fastapi/geoparquet/api.py
@@ -17,9 +17,11 @@ from starlette.background import BackgroundTask
 from .client import Client
 from .models import (
     EXTENSIONS,
+    CollectionSearchRequest,
     GetSearchRequestModel,
     ItemsGetRequestModel,
     PostSearchRequestModel,
+    collection_search_ext,
 )
 from .settings import Settings
 
@@ -191,7 +193,11 @@ def create(
         search_get_request_model=GetSearchRequestModel,
         search_post_request_model=PostSearchRequestModel,
         items_get_request_model=ItemsGetRequestModel,
-        extensions=EXTENSIONS,
+        collections_get_request_model=CollectionSearchRequest,
+        # collection_search_ext contributes conformance classes only (its
+        # register() is a no-op); the /collections request model is the
+        # hand-crafted CollectionSearchRequest above.
+        extensions=[*EXTENSIONS, collection_search_ext],
     )
     return api
 

--- a/src/stac_fastapi/geoparquet/client.py
+++ b/src/stac_fastapi/geoparquet/client.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import urllib.parse
+from datetime import datetime as dt
 from typing import Any, cast
 
 from fastapi import HTTPException
@@ -24,22 +25,168 @@ class Client(BaseCoreClient):
     def all_collections(self, **kwargs: Any) -> Collections:
         request = kwargs.pop("request")
         collections = cast(dict[str, Collection], request.state.collections)
+
+        # ---- collection search parameters (injected by CollectionSearchRequest) --
+        ids: list[str] | None = kwargs.pop("ids", None)
+        bbox: tuple[float, float, float, float] | None = kwargs.pop("bbox", None)
+        datetime_str: str | None = kwargs.pop("datetime", None)
+        q: list[str] | None = kwargs.pop("q", None)
+        limit: int | None = kwargs.pop("limit", None)
+        offset: int | None = kwargs.pop("offset", None)
+
+        matched = list(collections.values())
+
+        # Filter by ids — exact match OR partial substring match.
+        # A collection passes if its id exactly equals any term OR contains any
+        # term as a substring (case-insensitive), so `ids=naip` matches both
+        # "naip" and "naip-10".
+        if ids:
+            ids_lower = [term.lower() for term in ids]
+
+            def _id_matches(coll_id: str) -> bool:
+                cid = coll_id.lower()
+                return any(term == cid or term in cid for term in ids_lower)
+
+            matched = [c for c in matched if _id_matches(c.get("id", ""))]
+
+        # Free-text search over title, description and keywords — the fields
+        # the Free-Text Search extension names for collections. Any term
+        # matching is enough (OR), and matching is case-insensitive and
+        # partial.
+        if q:
+
+            def _matches_q(coll: Collection, terms: list[str]) -> bool:
+                haystack = " ".join(
+                    filter(
+                        None,
+                        [
+                            coll.get("title", ""),
+                            coll.get("description", ""),
+                            " ".join(coll.get("keywords", [])),
+                        ],
+                    )
+                ).lower()
+                return any(term.lower() in haystack for term in terms)
+
+            matched = [c for c in matched if _matches_q(c, q)]
+
+        # Spatial filter: collection extent bbox must overlap request bbox
+        if bbox:
+            req_min_lon, req_min_lat, req_max_lon, req_max_lat = (
+                float(bbox[0]),
+                float(bbox[1]),
+                float(bbox[2]),
+                float(bbox[3]),
+            )
+
+            def _extent_overlaps_bbox(coll: Collection) -> bool:
+                try:
+                    coll_bbox = (
+                        coll.get("extent", {}).get("spatial", {}).get("bbox", [[]])[0]
+                    )
+                    if not coll_bbox or len(coll_bbox) < 4:
+                        return True  # no spatial info — include by default
+                    c_min_lon, c_min_lat, c_max_lon, c_max_lat = (
+                        float(coll_bbox[0]),
+                        float(coll_bbox[1]),
+                        float(coll_bbox[2]),
+                        float(coll_bbox[3]),
+                    )
+                    # Overlaps when NOT (one is entirely to the left/right/above/below)
+                    return not (
+                        c_max_lon < req_min_lon
+                        or c_min_lon > req_max_lon
+                        or c_max_lat < req_min_lat
+                        or c_min_lat > req_max_lat
+                    )
+                except Exception:
+                    return True
+
+            matched = [c for c in matched if _extent_overlaps_bbox(c)]
+
+        # Temporal filter: collection temporal extent must overlap request datetime
+        if datetime_str:
+            req_start, req_end = _parse_datetime_interval(datetime_str)
+
+            def _temporal_overlaps(coll: Collection) -> bool:
+                try:
+                    interval = (
+                        coll.get("extent", {})
+                        .get("temporal", {})
+                        .get("interval", [[None, None]])[0]
+                    )
+                    coll_start_str, coll_end_str = interval[0], interval[1]
+                    coll_start = (
+                        _parse_rfc3339(coll_start_str) if coll_start_str else None
+                    )
+                    coll_end = _parse_rfc3339(coll_end_str) if coll_end_str else None
+                    # Open collection end means "still active"
+                    effective_end = coll_end if coll_end else dt.max
+                    effective_start = coll_start if coll_start else dt.min
+                    effective_req_end = req_end if req_end else dt.max
+                    effective_req_start = req_start if req_start else dt.min
+                    return (
+                        effective_start <= effective_req_end
+                        and effective_end >= effective_req_start
+                    )
+                except Exception:
+                    return True
+
+            matched = [c for c in matched if _temporal_overlaps(c)]
+
+        # Pagination
+        total_matched = len(matched)
+        applied_offset = offset or 0
+        applied_limit = limit or total_matched
+        page = matched[applied_offset : applied_offset + applied_limit]
+
+        # Build next/prev links if paginating
+        links: list[dict[str, Any]] = [
+            {
+                "href": str(request.url_for("Landing Page")),
+                "rel": "root",
+                "type": "application/json",
+            },
+            {
+                "href": str(request.url),
+                "rel": "self",
+                "type": "application/json",
+            },
+        ]
+        next_offset = applied_offset + applied_limit
+        if next_offset < total_matched:
+            next_params = dict(request.query_params)
+            next_params["offset"] = str(next_offset)
+            if limit:
+                next_params["limit"] = str(applied_limit)
+            links.append(
+                {
+                    "href": str(request.url_for("Get Collections"))
+                    + "?"
+                    + urllib.parse.urlencode(next_params),
+                    "rel": "next",
+                    "type": "application/json",
+                }
+            )
+        if applied_offset > 0:
+            prev_offset = max(0, applied_offset - applied_limit)
+            prev_params = dict(request.query_params)
+            prev_params["offset"] = str(prev_offset)
+            if limit:
+                prev_params["limit"] = str(applied_limit)
+            links.append(
+                {
+                    "href": str(request.url_for("Get Collections"))
+                    + "?"
+                    + urllib.parse.urlencode(prev_params),
+                    "rel": "prev",
+                    "type": "application/json",
+                }
+            )
+
         return Collections(
-            collections=[
-                collection_with_links(c, request) for c in collections.values()
-            ],
-            links=[
-                {
-                    "href": str(request.url_for("Landing Page")),
-                    "rel": "root",
-                    "type": "application/json",
-                },
-                {
-                    "href": str(request.url_for("Get Collections")),
-                    "rel": "self",
-                    "type": "application/json",
-                },
-            ],
+            collections=[collection_with_links(c, request) for c in page],
+            links=links,
         )
 
     def get_collection(self, collection_id: str, **kwargs: Any) -> Collection:
@@ -350,3 +497,33 @@ def collection_with_links(collection: Collection, request: Request) -> Collectio
         },
     ]
     return collection
+
+
+# ---------------------------------------------------------------------------
+# Helpers for temporal collection search
+# ---------------------------------------------------------------------------
+
+
+def _parse_rfc3339(value: str) -> dt:
+    """Parse an RFC 3339 datetime string, handling the trailing 'Z'."""
+    return dt.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _parse_datetime_interval(value: str) -> tuple[dt | None, dt | None]:
+    """Parse a STAC datetime/interval string into (start, end).
+
+    Single datetime  →  (datetime, datetime)
+    Closed interval  →  (start, end)
+    Open start (..)  →  (None, end)
+    Open end   (..)  →  (start, None)
+    """
+    if "/" not in value:
+        d = _parse_rfc3339(value.strip())
+        return d, d
+
+    raw_start, raw_end = value.split("/", 1)
+    start = (
+        None if raw_start.strip() in ("..", "") else _parse_rfc3339(raw_start.strip())
+    )
+    end = None if raw_end.strip() in ("..", "") else _parse_rfc3339(raw_end.strip())
+    return start, end

--- a/src/stac_fastapi/geoparquet/models.py
+++ b/src/stac_fastapi/geoparquet/models.py
@@ -1,12 +1,22 @@
+from typing import Annotated
+
+import attr
 import stac_fastapi.api.models
+from fastapi import Query
 from stac_fastapi.api.models import ItemCollectionUri
+from stac_fastapi.extensions.core.collection_search import CollectionSearchExtension
 from stac_fastapi.extensions.core.fields import FieldsExtension
 from stac_fastapi.extensions.core.filter import SearchFilterExtension
+from stac_fastapi.extensions.core.free_text import (
+    FreeTextConformanceClasses,
+    FreeTextExtension,
+)
 from stac_fastapi.extensions.core.pagination import OffsetPaginationExtension
 from stac_fastapi.extensions.core.sort import SortExtension
-from stac_fastapi.types.search import BaseSearchPostRequest
+from stac_fastapi.types.search import APIRequest, BaseSearchPostRequest
+from stac_pydantic.shared import BBox
 
-from .search import FixedSearchGetRequest
+from .search import FixedSearchGetRequest, _bbox_converter, _ids_converter
 
 EXTENSIONS = [
     OffsetPaginationExtension(),
@@ -24,3 +34,88 @@ PostSearchRequestModel = stac_fastapi.api.models.create_post_request_model(
 ItemsGetRequestModel = stac_fastapi.api.models.create_get_request_model(
     base_model=ItemCollectionUri, extensions=EXTENSIONS
 )
+
+
+# ---------------------------------------------------------------------------
+# Collection-search extensions (used for GET /collections)
+#
+# Only advertise what `Client.all_collections` actually implements:
+# ids/bbox/datetime/limit (core collection-search) plus free-text `q`.
+# ---------------------------------------------------------------------------
+
+collection_search_ext = CollectionSearchExtension.from_extensions(
+    [FreeTextExtension(conformance_classes=[FreeTextConformanceClasses.COLLECTIONS])]
+)
+
+
+def _q_converter(
+    val: Annotated[
+        str | None,
+        Query(
+            description=(
+                "Free-text search terms, comma-separated. A collection matches "
+                "if any term appears in its title, description, or keywords "
+                "(case-insensitive, partial matches count)."
+            ),
+            openapi_examples={
+                "user-provided": {"value": None},
+                "single-term": {"value": "imagery"},
+                "multi-term": {"value": "ocean,coast"},
+            },
+        ),
+    ] = None,
+) -> list[str] | None:
+    """Split a comma-separated free-text query string into individual terms.
+
+    Comma-separated with OR semantics is what the Free-Text Search extension
+    specifies; spaces carry no meaning, so a term may contain them.
+    """
+    if val:
+        return [term.strip() for term in val.split(",") if term.strip()]
+    return None
+
+
+@attr.s
+class CollectionSearchRequest(APIRequest):
+    """Query parameters for ``GET /collections`` collection search."""
+
+    ids: list[str] | None = attr.ib(default=None, converter=_ids_converter)
+    bbox: BBox | None = attr.ib(default=None, converter=_bbox_converter)
+    datetime: Annotated[
+        str | None,
+        Query(
+            description=(
+                "Only return collections whose temporal extent overlaps this value. "
+                "Either a date-time or an interval (open or closed). "
+                "Date and time expressions adhere to RFC 3339. "
+                "Open intervals are expressed using double-dots."
+            ),
+            openapi_examples={
+                "user-provided": {"value": None},
+                "datetime": {"value": "2018-02-12T23:20:50Z"},
+                "closed-interval": {
+                    "value": "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"
+                },
+                "open-interval-from": {"value": "2018-02-12T00:00:00Z/.."},
+                "open-interval-to": {"value": "../2018-03-18T12:31:12Z"},
+            },
+        ),
+    ] = attr.ib(default=None)
+    q: list[str] | None = attr.ib(default=None, converter=_q_converter)
+    limit: Annotated[
+        int | None,
+        Query(
+            ge=1,
+            le=10_000,
+            description="Maximum number of collections to return (1–10 000).",
+        ),
+    ] = attr.ib(default=None)
+    offset: Annotated[
+        int | None,
+        Query(ge=0, description="Number of collections to skip for pagination."),
+    ] = attr.ib(default=None)
+
+
+# Override the GET model with the hand-crafted one so the /collections
+# endpoint uses CollectionSearchRequest instead of the auto-generated model.
+collection_search_ext.GET = CollectionSearchRequest

--- a/tests/test_collection_search.py
+++ b/tests/test_collection_search.py
@@ -1,0 +1,247 @@
+"""Tests for GET /collections collection search parameters."""
+
+import urllib.parse
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+# IDs present in data/collections.json
+ALL_IDS = {"naip", "naip-10", "openaerialmap-10", "openaerialmap"}
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _get_collections(client: TestClient, **params: Any) -> dict[str, Any]:
+    response = client.get("/collections", params=params)
+    assert response.status_code == 200, response.text
+    result = response.json()
+    assert isinstance(result, dict)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Baseline
+# ---------------------------------------------------------------------------
+
+
+def test_all_collections_returned_by_default(client: TestClient) -> None:
+    data = _get_collections(client)
+    ids = {c["id"] for c in data["collections"]}
+    assert ids == ALL_IDS
+
+
+# ---------------------------------------------------------------------------
+# ids filter
+# ---------------------------------------------------------------------------
+
+
+def test_filter_by_exact_id(client: TestClient) -> None:
+    # Exact match — only "naip" (not "naip-10") when the term equals the id.
+    # Note: "naip" is a substring of "naip-10", so both match under partial rules.
+    # To test exact-only behaviour use a term that isn't a substring of anything else.
+    data = _get_collections(client, ids="openaerialmap-10")
+    assert len(data["collections"]) == 1
+    assert data["collections"][0]["id"] == "openaerialmap-10"
+
+
+def test_filter_by_partial_id_substring(client: TestClient) -> None:
+    # "naip" is a substring of "naip" and "naip-10" — both should be returned.
+    data = _get_collections(client, ids="naip")
+    ids = {c["id"] for c in data["collections"]}
+    assert ids == {"naip", "naip-10"}
+
+
+def test_filter_partial_id_prefix(client: TestClient) -> None:
+    # "openaerialmap" matches "openaerialmap" and "openaerialmap-10".
+    data = _get_collections(client, ids="openaerialmap")
+    ids = {c["id"] for c in data["collections"]}
+    assert ids == {"openaerialmap", "openaerialmap-10"}
+
+
+def test_filter_by_multiple_partial_ids(client: TestClient) -> None:
+    # Two terms — union of their partial matches.
+    data = _get_collections(client, ids="naip,openaerialmap-10")
+    ids = {c["id"] for c in data["collections"]}
+    # "naip" → naip + naip-10; "openaerialmap-10" → openaerialmap-10 (exact)
+    assert ids == {"naip", "naip-10", "openaerialmap-10"}
+
+
+def test_filter_partial_id_case_insensitive(client: TestClient) -> None:
+    data = _get_collections(client, ids="NAIP")
+    ids = {c["id"] for c in data["collections"]}
+    assert ids == {"naip", "naip-10"}
+
+
+def test_filter_by_unknown_id_returns_empty(client: TestClient) -> None:
+    data = _get_collections(client, ids="does-not-exist")
+    assert data["collections"] == []
+
+
+# ---------------------------------------------------------------------------
+# q (free-text) filter
+# ---------------------------------------------------------------------------
+
+
+def test_freetext_matches_description(client: TestClient) -> None:
+    # All test collections share the word "rustac" in their description.
+    data = _get_collections(client, q="rustac")
+    ids = {c["id"] for c in data["collections"]}
+    assert ids == ALL_IDS
+
+
+def test_freetext_no_match_returns_empty(client: TestClient) -> None:
+    data = _get_collections(client, q="zzznomatchzzz")
+    assert data["collections"] == []
+
+
+def test_freetext_comma_separated_terms_are_or_ed(client: TestClient) -> None:
+    # The Free-Text extension separates terms with commas and matches any of
+    # them, so an unmatched term must not narrow the result.
+    data = _get_collections(client, q="zzznomatchzzz,rustac")
+    assert {c["id"] for c in data["collections"]} == ALL_IDS
+
+    # Only "naip" has "10000 items" in its description.
+    data = _get_collections(client, q="10000,zzznomatchzzz")
+    assert {c["id"] for c in data["collections"]} == {"naip"}
+
+
+def test_freetext_spaces_are_part_of_the_term(client: TestClient) -> None:
+    # Spaces have no special meaning: this is one term, not two.
+    data = _get_collections(client, q="from 10000 items")
+    assert {c["id"] for c in data["collections"]} == {"naip"}
+
+    # ... so the same words in the wrong order match nothing.
+    data = _get_collections(client, q="10000 from items")
+    assert data["collections"] == []
+
+
+def test_freetext_is_case_insensitive(client: TestClient) -> None:
+    data = _get_collections(client, q="RUSTAC")
+    assert {c["id"] for c in data["collections"]} == ALL_IDS
+
+
+# ---------------------------------------------------------------------------
+# bbox filter
+# ---------------------------------------------------------------------------
+
+
+def test_bbox_overlapping_naip(client: TestClient) -> None:
+    # naip bbox: -109.13, 36.93, -101.99, 41.07  (Colorado / Wyoming)
+    data = _get_collections(client, bbox="-108,37,-102,41")
+    ids = {c["id"] for c in data["collections"]}
+    assert "naip" in ids
+    assert "naip-10" in ids  # naip-10 is within naip's extent
+
+
+def test_bbox_no_overlap_returns_empty(client: TestClient) -> None:
+    # Use a bbox over the middle of the Pacific — no collection covers it exclusively
+    # openaerialmap covers almost the whole world, so use an Arctic bbox
+    data = _get_collections(client, bbox="0,80,10,90")
+    # naip and naip-10 are entirely in the US mid-west, so they should be excluded
+    ids = {c["id"] for c in data["collections"]}
+    assert "naip" not in ids
+    assert "naip-10" not in ids
+
+
+# ---------------------------------------------------------------------------
+# datetime filter
+# ---------------------------------------------------------------------------
+
+
+def test_datetime_single_overlapping(client: TestClient) -> None:
+    # naip temporal: 2019-09-19 → 2022-08-27
+    data = _get_collections(client, datetime="2021-01-01T00:00:00Z")
+    ids = {c["id"] for c in data["collections"]}
+    assert "naip" in ids
+
+
+def test_datetime_interval_no_overlap(client: TestClient) -> None:
+    # Before all collections (naip starts 2019-09-19)
+    data = _get_collections(
+        client, datetime="1900-01-01T00:00:00Z/1901-01-01T00:00:00Z"
+    )
+    ids = {c["id"] for c in data["collections"]}
+    assert "naip" not in ids
+    assert "naip-10" not in ids
+
+
+def test_datetime_open_end_interval(client: TestClient) -> None:
+    # Open-ended from 2020 should include naip
+    data = _get_collections(client, datetime="2020-01-01T00:00:00Z/..")
+    ids = {c["id"] for c in data["collections"]}
+    assert "naip" in ids
+
+
+# ---------------------------------------------------------------------------
+# limit / offset (pagination)
+# ---------------------------------------------------------------------------
+
+
+def test_limit_reduces_result_count(client: TestClient) -> None:
+    data = _get_collections(client, limit=2)
+    assert len(data["collections"]) == 2
+
+
+def test_offset_skips_first_n(client: TestClient) -> None:
+    all_data = _get_collections(client)
+    all_ids = [c["id"] for c in all_data["collections"]]
+
+    offset_data = _get_collections(client, offset=1)
+    offset_ids = [c["id"] for c in offset_data["collections"]]
+
+    assert offset_ids == all_ids[1:]
+
+
+def test_limit_and_offset_together(client: TestClient) -> None:
+    all_data = _get_collections(client)
+    all_ids = [c["id"] for c in all_data["collections"]]
+
+    paged = _get_collections(client, limit=2, offset=1)
+    assert [c["id"] for c in paged["collections"]] == all_ids[1:3]
+
+
+def test_next_link_present_when_more_results(client: TestClient) -> None:
+    data = _get_collections(client, limit=1)
+    rels = {link["rel"] for link in data["links"]}
+    assert "next" in rels
+
+
+def test_no_next_link_when_all_results_returned(client: TestClient) -> None:
+    data = _get_collections(client)
+    rels = {link["rel"] for link in data["links"]}
+    assert "next" not in rels
+
+
+def test_prev_link_present_after_offset(client: TestClient) -> None:
+    data = _get_collections(client, limit=2, offset=2)
+    rels = {link["rel"] for link in data["links"]}
+    assert "prev" in rels
+
+
+def test_next_link_href_encodes_offset(client: TestClient) -> None:
+    data = _get_collections(client, limit=1)
+    next_link = next(link for link in data["links"] if link["rel"] == "next")
+    parsed = urllib.parse.urlparse(next_link["href"])
+    qs = urllib.parse.parse_qs(parsed.query)
+    assert qs["offset"] == ["1"]
+    assert qs["limit"] == ["1"]
+
+
+# ---------------------------------------------------------------------------
+# Combined filters
+# ---------------------------------------------------------------------------
+
+
+def test_ids_and_q_combined(client: TestClient) -> None:
+    # "openaerialmap" (partial) matches openaerialmap + openaerialmap-10;
+    # q="17702" further narrows to the one with "17702 items" in its description.
+    data = _get_collections(client, ids="openaerialmap", q="17702")
+    ids = {c["id"] for c in data["collections"]}
+    assert ids == {"openaerialmap"}
+
+
+def test_bbox_and_limit(client: TestClient) -> None:
+    data = _get_collections(client, bbox="-180,-90,180,90", limit=2)
+    assert len(data["collections"]) <= 2


### PR DESCRIPTION
Implements the Collection Search extension: `ids`, `bbox`, `datetime`, free-text `q`, and `limit`/`offset` paging, filtered in memory over the collections already held in state.

Matching follows the extension where it is specific, and is otherwise kept predictable:

- **`ids`** matches exactly or as a case-insensitive substring, so `ids=naip` finds both `naip` and `naip-10`.
- **`bbox`** and **`datetime`** keep a collection whose extent overlaps the request. A collection with no usable extent is kept rather than dropped — an absent extent says nothing about whether it matches.
- **`q`** takes comma-separated terms and matches any of them (OR), case-insensitively and partially, against title, description and keywords — the fields the Free-Text extension names for collections.

Paging adds `next`/`prev` links built from the request's own query string.

### On the request model

The GET model is a hand-written `CollectionSearchRequest` rather than the one `CollectionSearchExtension` generates, so the endpoint advertises exactly the parameters implemented here; the extension is passed for its conformance classes only. Happy to switch to the generated model if you'd rather advertise the full parameter set and implement the remainder.

### Verification

26 new tests. `scripts/lint` and `scripts/test` pass.
