### PR TITLE
feat: implement free-text search (`q`)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,14 @@ description = "A stac-fastapi implementation with a stac-geoparquet backend"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
+    "arro3-core>=0.8.0",
     "attr>=0.3.2",
     "fastapi>=0.115.8",
     "geojson-pydantic>=1.2.0",
     "obstore>=0.8.0",
     "pydantic>=2.10.4",
     "pystac>=1.13.0",
-    "rustac>=0.7.0",
+    "rustac>=0.9.11",
     "stac-fastapi-api>=5.0.2",
     "stac-fastapi-extensions>=5.0.2",
     "stac-fastapi-types>=5.0.2",

--- a/src/stac_fastapi/geoparquet/client.py
+++ b/src/stac_fastapi/geoparquet/client.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import logging
 import urllib.parse
 from typing import Any, cast
 
@@ -14,12 +15,136 @@ from stac_pydantic.shared import BBox
 from starlette.requests import Request
 
 from .models import PostSearchRequestModel
+from .schema import describe_columns, text_columns
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_LIMIT = 10_000
+
+# Free-text searchable columns, keyed by geoparquet href. A file's schema
+# doesn't change under us, and the alternative is a DESCRIBE per `q` search.
+_TEXT_COLUMNS_CACHE: dict[str, list[str]] = {}
+
+
+def _cql2_text_identifier(prop: str) -> str:
+    """Quote a property name for CQL2-text so it can't inject filter syntax."""
+    return '"' + prop.replace('"', '""') + '"'
+
+
+def _cql2_text_literal(value: str) -> str:
+    """Quote a string for CQL2-text."""
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _free_text_clauses_text(terms: list[str], columns: list[str]) -> list[str]:
+    """One CQL2-text predicate per (term, column) pair.
+
+    Per the Free-Text Search extension matching is case-insensitive and
+    partial, hence ``CASEI`` around a ``LIKE '%term%'``.
+    """
+    return [
+        f"CASEI({_cql2_text_identifier(column)}) LIKE "
+        f"CASEI({_cql2_text_literal(f'%{term}%')})"
+        for term in terms
+        for column in columns
+    ]
+
+
+def _free_text_clauses_json(
+    terms: list[str], columns: list[str]
+) -> list[dict[str, Any]]:
+    """The CQL2-json equivalent of :func:`_free_text_clauses_text`."""
+    return [
+        {
+            "op": "like",
+            "args": [
+                {"op": "casei", "args": [{"property": column}]},
+                {"op": "casei", "args": [f"%{term}%"]},
+            ],
+        }
+        for term in terms
+        for column in columns
+    ]
+
+
+def _apply_free_text(
+    search_dict: dict[str, Any],
+    terms: list[str],
+    columns: list[str],
+    filter_lang: str,
+) -> None:
+    """Fold a free-text search into ``search_dict``'s filter, in place.
+
+    An item matches if any term appears in any text column, so the natural
+    encoding is ``existing AND (a OR b OR ...)``. That form is miscomputed by
+    the backend today: a parenthesised OR nested under an AND loses its
+    grouping on the way to SQL, so rows that fail ``existing`` come back
+    anyway. Distributing the disjunction into ``(existing AND a) OR (existing
+    AND b)`` needs no grouping to survive, because SQL binds AND tighter than
+    OR.
+    """
+    existing = search_dict.get("filter")
+    if filter_lang == "cql2-text":
+        clauses = _free_text_clauses_text(terms, columns)
+        if existing:
+            search_dict["filter"] = " OR ".join(
+                f"({existing}) AND ({clause})" for clause in clauses
+            )
+        else:
+            search_dict["filter"] = " OR ".join(clauses)
+    else:
+        json_clauses: list[Any] = list(_free_text_clauses_json(terms, columns))
+        if existing:
+            json_clauses = [
+                {"op": "and", "args": [existing, clause]} for clause in json_clauses
+            ]
+        search_dict["filter"] = (
+            json_clauses[0]
+            if len(json_clauses) == 1
+            else {"op": "or", "args": json_clauses}
+        )
+    search_dict["filter-lang"] = filter_lang
 
 
 class Client(BaseCoreClient):
     """A stac-fastapi-geoparquet client."""
+
+    def text_columns(self, href: str, request: Request) -> list[str]:
+        """Return the columns a free-text search should look at."""
+        if href not in _TEXT_COLUMNS_CACHE:
+            client = cast(DuckdbClient, request.state.client)
+            try:
+                columns = text_columns(describe_columns(client, href))
+            except Exception:
+                logger.exception("Could not read the schema of %s", href)
+                columns = []
+            _TEXT_COLUMNS_CACHE[href] = columns
+        return _TEXT_COLUMNS_CACHE[href]
+
+    def visible_collections(self, request: Request) -> dict[str, Collection]:
+        """Return the collections this request is allowed to see.
+
+        Every endpoint goes through here instead of reading
+        ``request.state.collections`` directly, so a subclass can hide
+        collections from a caller by overriding this one method.
+        """
+        return cast(dict[str, Collection], request.state.collections)
+
+    def search_collection(
+        self,
+        collection_id: str,
+        href: str,
+        search_dict: dict[str, Any],
+        request: Request,
+    ) -> list[Item]:
+        """Run one collection's share of a search against its geoparquet.
+
+        The single point where a search reaches the DuckDB client, so a
+        subclass can adjust ``search_dict`` (extra filters, extra projected
+        columns) or post-process the returned items.
+        """
+        client = cast(DuckdbClient, request.state.client)
+        return cast(list[Item], client.search(href, **search_dict))
 
     def all_collections(self, **kwargs: Any) -> Collections:
         request = kwargs.pop("request")
@@ -162,15 +287,24 @@ class Client(BaseCoreClient):
             collections = list(hrefs.keys())
 
         search_dict = search.model_dump(exclude_none=True, by_alias=True)
-        search_dict.update(**kwargs)
+        # A GET parameter the caller didn't provide arrives as None. The POST
+        # body already excludes those (`exclude_none`); do the same here so an
+        # unset parameter isn't forwarded to the backend or echoed into the
+        # pagination links as the literal string "None".
+        search_dict.update({k: v for k, v in kwargs.items() if v is not None})
 
         search_dict.pop("filter_crs", None)
         if filter_expr := search_dict.pop("filter_expr", None):
             search_dict["filter"] = filter_expr
-        if filter_lang := search_dict.pop("filter_lang", None):
+        # POST spells it "filter-lang" (the pydantic alias) and GET spells it
+        # "filter_lang" (a Python identifier, via the dependency function), so
+        # both are read here.
+        filter_lang: str | None = search_dict.pop(
+            "filter-lang", None
+        ) or search_dict.pop("filter_lang", None)
+        if filter_lang:
             search_dict["filter-lang"] = filter_lang
         if "filter" not in search_dict:
-            search_dict.pop("filter_lang", None)
             search_dict.pop("filter-lang", None)
         if fields := search_dict.pop("fields", None):
             if isinstance(fields, list):
@@ -194,6 +328,21 @@ class Client(BaseCoreClient):
         if sortby := search_dict.pop("sortby", None):
             search_dict["sortby"] = sortby
 
+        # The Free-Text extension's `q` is resolved per collection (the set of
+        # text columns differs between them), so it's translated inside the
+        # loop below rather than here.
+        free_text: list[str] | None = search_dict.get("q") or None
+        if isinstance(free_text, str):
+            # GET requests hand it over as a comma-separated string.
+            free_text = [term.strip() for term in free_text.split(",") if term.strip()]
+        if free_text:
+            filter_lang = filter_lang or "cql2-text"
+            if filter_lang not in ("cql2-text", "cql2-json"):
+                raise HTTPException(
+                    400,
+                    f"Unsupported filter-lang for the 'q' parameter: {filter_lang!r}",
+                )
+
         limit = search_dict.get("limit", DEFAULT_LIMIT)
         offset = search_dict.get("offset", 0) or 0
         items: list[Item] = []
@@ -208,6 +357,21 @@ class Client(BaseCoreClient):
                         "offset": offset,
                     }
                 )
+                # rustac has no free-text search of its own, so `q` becomes a
+                # CQL2 filter over this collection's text columns.
+                collection_search_dict.pop("q", None)
+                if free_text:
+                    columns = self.text_columns(href, request)
+                    if not columns:
+                        # Nothing searchable here, so nothing can match.
+                        continue
+                    _apply_free_text(
+                        collection_search_dict,
+                        free_text,
+                        columns,
+                        cast(str, filter_lang),
+                    )
+
                 collection_items = client.search(href, **collection_search_dict)
                 for item in collection_items:
                     # Careful ... we aren't updating `collection_items` with the

--- a/src/stac_fastapi/geoparquet/models.py
+++ b/src/stac_fastapi/geoparquet/models.py
@@ -2,6 +2,7 @@ import stac_fastapi.api.models
 from stac_fastapi.api.models import ItemCollectionUri
 from stac_fastapi.extensions.core.fields import FieldsExtension
 from stac_fastapi.extensions.core.filter import SearchFilterExtension
+from stac_fastapi.extensions.core.free_text import FreeTextExtension
 from stac_fastapi.extensions.core.pagination import OffsetPaginationExtension
 from stac_fastapi.extensions.core.sort import SortExtension
 from stac_fastapi.types.search import BaseSearchPostRequest
@@ -12,6 +13,7 @@ EXTENSIONS = [
     OffsetPaginationExtension(),
     SearchFilterExtension(),
     FieldsExtension(),
+    FreeTextExtension(),
     SortExtension(),
 ]
 

--- a/src/stac_fastapi/geoparquet/schema.py
+++ b/src/stac_fastapi/geoparquet/schema.py
@@ -1,0 +1,50 @@
+"""Reading a geoparquet file's column schema."""
+
+from typing import Any, cast
+
+from rustac import DuckdbClient
+
+# Columns that are structural STAC members rather than searchable metadata.
+STRUCTURAL_COLUMNS: frozenset[str] = frozenset(
+    {
+        "type",
+        "stac_version",
+        "stac_extensions",
+        "links",
+        "assets",
+        "providers",
+        "bbox",
+        "geometry",
+    }
+)
+
+_TEXT_TYPES: frozenset[str] = frozenset({"VARCHAR", "TEXT", "STRING", "CHAR", "BPCHAR"})
+
+
+def describe_columns(client: DuckdbClient, href: str) -> list[tuple[str, str]]:
+    """Return ``(name, duckdb type)`` for every column in a geoparquet file.
+
+    Raises whatever DuckDB raises if the file can't be read; callers decide
+    whether an unreadable file is fatal.
+    """
+    safe_href = href.replace("'", "''")
+    table = client.query_to_table(
+        f"DESCRIBE SELECT * FROM read_parquet('{safe_href}') LIMIT 0"
+    )
+    names = cast(list[str], table.column("column_name").to_pylist())
+    types = cast(list[str], table.column("column_type").to_pylist())
+    return list(zip(names, types))
+
+
+def text_columns(columns: list[tuple[str, Any]]) -> list[str]:
+    """Pick the plain-text columns worth searching from a DESCRIBE result.
+
+    Structural members are dropped: matching every item because its `type` is
+    "Feature" is not what a free-text search means.
+    """
+    return [
+        name
+        for name, column_type in columns
+        if name not in STRUCTURAL_COLUMNS
+        and str(column_type).upper().strip() in _TEXT_TYPES
+    ]

--- a/tests/test_free_text.py
+++ b/tests/test_free_text.py
@@ -1,0 +1,116 @@
+"""Tests for the Free-Text Search extension on item search.
+
+The extension specifies comma-separated terms, OR semantics between them,
+and case-insensitive partial matching over an item's textual properties.
+"""
+
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+# An id from data/naip.parquet, and the tile number inside it.
+ITEM_ID = "ne_m_4110264_sw_13_060_20220827"
+ITEM_ID_FRAGMENT = "4110264"
+
+
+def _ids(client: TestClient, **params: Any) -> list[str]:
+    response = client.get(
+        "/search", params={"collections": "naip", "limit": 10_000, **params}
+    )
+    response.raise_for_status()
+    return [feature["id"] for feature in response.json()["features"]]
+
+
+def test_q_matches_a_text_property(client: TestClient) -> None:
+    # `naip:state` is "ne" for a subset of the items.
+    matched = _ids(client, q="ne")
+    assert matched
+    assert len(matched) < len(_ids(client))
+
+
+def test_q_matches_the_id(client: TestClient) -> None:
+    assert _ids(client, q=ITEM_ID) == [ITEM_ID]
+
+
+def test_q_matches_partially(client: TestClient) -> None:
+    matched = _ids(client, q=ITEM_ID_FRAGMENT)
+    assert ITEM_ID in matched
+    assert all(ITEM_ID_FRAGMENT in item_id for item_id in matched)
+
+
+def test_q_is_case_insensitive(client: TestClient) -> None:
+    assert _ids(client, q=ITEM_ID.upper()) == [ITEM_ID]
+
+
+def test_q_without_a_match_is_empty(client: TestClient) -> None:
+    assert _ids(client, q="zzznomatchzzz") == []
+
+
+def test_q_terms_are_or_ed(client: TestClient) -> None:
+    ne = set(_ids(client, q="ne"))
+    co = set(_ids(client, q="co"))
+    both = set(_ids(client, q="ne,co"))
+    assert ne and co
+    assert both == ne | co
+
+
+def test_q_is_and_ed_with_a_filter(client: TestClient) -> None:
+    # The caller's filter still applies; `q` narrows it further rather than
+    # replacing it. This fails if the free-text disjunction is encoded as
+    # `filter AND (a OR b)` - see `_apply_free_text` for why that form loses
+    # its grouping before it reaches SQL.
+    filtered = _ids(client, filter="naip:year='2022'")
+    combined = _ids(client, q="ne", filter="naip:year='2022'")
+    assert combined
+    assert set(combined) < set(filtered)
+    assert set(combined) < set(_ids(client, q="ne"))
+
+
+def test_q_post(client: TestClient) -> None:
+    response = client.post(
+        "/search", json={"collections": ["naip"], "limit": 10_000, "q": [ITEM_ID]}
+    )
+    response.raise_for_status()
+    assert [f["id"] for f in response.json()["features"]] == [ITEM_ID]
+
+
+def test_q_post_with_a_cql2_json_filter(client: TestClient) -> None:
+    response = client.post(
+        "/search",
+        json={
+            "collections": ["naip"],
+            "limit": 10_000,
+            "q": ["ne"],
+            "filter": {"op": "=", "args": [{"property": "naip:year"}, "2022"]},
+            "filter-lang": "cql2-json",
+        },
+    )
+    response.raise_for_status()
+    features = response.json()["features"]
+    assert features
+    assert all(f["properties"]["naip:year"] == "2022" for f in features)
+
+
+def test_q_is_advertised_as_conformant(client: TestClient) -> None:
+    conforms_to = client.get("/").json()["conformsTo"]
+    assert any("item-search#free-text" in uri for uri in conforms_to)
+
+
+def test_q_survives_paging(client: TestClient) -> None:
+    response = client.get(
+        "/search", params={"collections": "naip", "limit": 1, "q": ITEM_ID_FRAGMENT}
+    )
+    response.raise_for_status()
+    data = response.json()
+    assert len(data["features"]) == 1
+    next_link = next(
+        (link for link in data["links"] if link["rel"] == "next"),
+        None,
+    )
+    assert next_link is not None
+    assert "q" in next_link["href"]
+
+    response = client.get(next_link["href"])
+    response.raise_for_status()
+    for feature in response.json()["features"]:
+        assert ITEM_ID_FRAGMENT in feature["id"]

--- a/uv.lock
+++ b/uv.lock
@@ -34,6 +34,59 @@ wheels = [
 ]
 
 [[package]]
+name = "arro3-core"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/68/db11c4ad146cc6625b68c3e33e4370de759950babbaac5b74a41164c91f9/arro3_core-0.8.2.tar.gz", hash = "sha256:51eac10b2113623a452b44480844a4edbd17bfc83f4545b56e1240636b7c2334", size = 92831, upload-time = "2026-09-03T08:03:30.386Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/fa/733457381266baa8ccd9dc916dcfee712d28d654be288c9a361cb77d2ad0/arro3_core-0.8.2-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f11104bccd3a6f210f8c1cf4d182ad8aaeca0f82f62c39a3b2f8f21c63b32cb3", size = 2998398, upload-time = "2026-09-03T08:01:58.841Z" },
+    { url = "https://files.pythonhosted.org/packages/28/30/cb2a2d09ee2829dd6aa16fb6df93729fe17d8ee4c01d56dfa87fa8c07a7d/arro3_core-0.8.2-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:c440eb44ab78397a783e4429490102967008a8b2383bd0f70433f4594689a7ee", size = 2754039, upload-time = "2026-09-03T08:02:00.559Z" },
+    { url = "https://files.pythonhosted.org/packages/82/27/384014251ac0d3f5c5b76ce816355dba2223e29564fab8d80b25f5462863/arro3_core-0.8.2-cp311-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6c48f9f2230f0869982021e7b92794456ffca99320565b7519fecd770e798cba", size = 3223780, upload-time = "2026-09-03T08:02:02.173Z" },
+    { url = "https://files.pythonhosted.org/packages/95/3c/e6dc5ae989d000159fed1172378efc9e8c49c17a9f52b1e724da507483e4/arro3_core-0.8.2-cp311-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6fbc60e277021b4d78dce1adaa2988040cbfb7ddf358ee5fa66ae30a96f3b184", size = 3335234, upload-time = "2026-09-03T08:02:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/38/d3/0b10a3e4617094494df3243f71092b5a210da0d3773d813ca2d5068fb763/arro3_core-0.8.2-cp311-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f51a5924a6503360cbc679015e1df88ce2515a3dd2cae3cf52c076f84be255ed", size = 3476780, upload-time = "2026-09-03T08:02:06.069Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/13/2adc42096a1b165064cabf17515e6cc7aa5490e71c3e570ff579f921e09f/arro3_core-0.8.2-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c5b361bf1a483536047bbf22568baeae66d72bb2c265d2ac4d45ef51f23c921", size = 3139773, upload-time = "2026-09-03T08:02:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/f4/b80b73004a713de878b0ee0348154db78b3c32f5156240035670d8811fa1/arro3_core-0.8.2-cp311-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:f0bcfddba1a461dc2b2edbbd814642c22492dfc2476d69efa3ab65dcdbfb6b9c", size = 2908405, upload-time = "2026-09-03T08:02:09.082Z" },
+    { url = "https://files.pythonhosted.org/packages/76/43/cf253c6fc47202cfc899b2d115265c28e2dc7873e03fa27324a0b3a2355f/arro3_core-0.8.2-cp311-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2618873ff8dd2d5141978cb43b5fe1ef095981ba957c456df680664e6d22c130", size = 3372617, upload-time = "2026-09-03T08:02:10.477Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/6c/987d09b09afe515af67a3523325ff1ba111b16cebb3c81deeca794dcc30a/arro3_core-0.8.2-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fbf5b07ebba94ea5fab381c9366217f78152705222a94ae00c97360333d9305d", size = 3088499, upload-time = "2026-09-03T08:02:12.042Z" },
+    { url = "https://files.pythonhosted.org/packages/83/85/b6189b91ef1a25c9208cbbe58cacc42293c84309eb7fd2deaca02870a68a/arro3_core-0.8.2-cp311-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:0ef906334704039f78d25c1beab653e3ec46ed14c8583f7c1e4e24d0a8f28b8d", size = 3502723, upload-time = "2026-09-03T08:02:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/d7/ae3bd97c2ebc9a79508c6789dcba9bfacd87d59ce67ee519b9651e2e808a/arro3_core-0.8.2-cp311-abi3-musllinux_1_2_i686.whl", hash = "sha256:836e32d604cdcad0e1943bbeeebcb5ae8211e19e661071358ea5a8443b8ae854", size = 3474134, upload-time = "2026-09-03T08:02:15.188Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/32/0d5e4b03b9564a7c58726c5b2b9591952a13cf5c84716adccb7669f88a1c/arro3_core-0.8.2-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b74963ca517a940632020a04f3613321d7bb198c9ed2e193590d27c592ae9853", size = 3359886, upload-time = "2026-09-03T08:02:16.731Z" },
+    { url = "https://files.pythonhosted.org/packages/24/5a/85edfa131fe52bcb33c9c9e9eab10dec197f039a74e05121d30784a205cd/arro3_core-0.8.2-cp311-abi3-win_amd64.whl", hash = "sha256:195d1003303e050da262b0727d107a2aa7271216f60283fff925612dd7d45c95", size = 3311607, upload-time = "2026-09-03T08:02:18.337Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/18/73fe6503a3a657a6ccde27d4917e95a52525adc19f981b978b208675d579/arro3_core-0.8.2-cp311-abi3-win_arm64.whl", hash = "sha256:6a57975132c3ee967be1c2a8dd3950ac17990a38b9774f671b78c66395e6d90f", size = 2961638, upload-time = "2026-09-03T08:02:20.158Z" },
+    { url = "https://files.pythonhosted.org/packages/25/0e/e487d2ea877073f140753445f0033145ab3c60ed3fe5445533cb6a34e84a/arro3_core-0.8.2-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:ed4c2a8d0deaf1da3ac497d0b97f3fd236ca531200c4ce23ec2649cec47da1dc", size = 1718880, upload-time = "2026-09-03T08:02:21.942Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/42/598184778b594bda7b2aed4b23908ddfd305138ef0934a0adedf5b2a7b25/arro3_core-0.8.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:a46bada55d9f6678d4738cef8169082c0d13ca495ec2a7b10b7956739a03fb6c", size = 1703773, upload-time = "2026-09-03T08:02:23.362Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/ec71aa5f59563e35f42047dfa38a1e2a52e96d0c32a4df02347bce7cb313/arro3_core-0.8.2-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:cecfeeb5c8a4468b00d15be84ee57d125bd888fd590051e290dd9a1003522495", size = 3017388, upload-time = "2026-09-03T08:02:24.722Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/e6/4c5293c663c7255cf69ee261c3cf951dd92ca3f9ec8a89bf9f58a9c8854c/arro3_core-0.8.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:508efa269e5a93a39c9fc2d624815aeebda446aa04388ac5b22dbf74d0d2a106", size = 2737056, upload-time = "2026-09-03T08:02:26.179Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/8a9dcaffac07c1fc9f76f2d1a5d458c40320323fdc0f6e74692da403a6a7/arro3_core-0.8.2-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:171b427c79058cf3ec6758794bafca2affaca061cecb07a0930f72e1460874cc", size = 3219201, upload-time = "2026-09-03T08:02:28.232Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/9a/3b273599a13ff8e8f92f560204b3335b2fe446480eda2709bebd7b3a4f7d/arro3_core-0.8.2-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:974245b76afa20528fdde6a57aa88efa22cfe27effab0580f198877bc0fb56fc", size = 3321140, upload-time = "2026-09-03T08:02:29.818Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/ce/8ac97dddd64bfbb188205f1869ea9eb6d0c2cd2bbad744ae3e65f336934c/arro3_core-0.8.2-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:22daff2943c803eb888b94036eeeb20ce9ddca649dfbbeb30c470ca4bf70e65b", size = 3481157, upload-time = "2026-09-03T08:02:31.438Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/03/1667805eaa865287f3c6480e22d3747bb92d46954048327a6934b906edfc/arro3_core-0.8.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:858fe80ebec6fb172ce760979bc51d15f370f0cd11f50db61e2516912eb244c8", size = 3132210, upload-time = "2026-09-03T08:02:32.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/0f/7e4b90f0b15898ceb09fe7a81818d33143daaf512f20077a0ccee365335d/arro3_core-0.8.2-cp314-cp314t-manylinux_2_24_aarch64.whl", hash = "sha256:955428a268b44e6cb1be18bc69ad4cc4d114e8a4db87aacb9f6b216ddf7c5762", size = 2902939, upload-time = "2026-09-03T08:02:34.444Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b9/7fc0e89aa6640183ea368c27f53255aea111290eed91f0e2c66527e8e7bc/arro3_core-0.8.2-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:216deb890962ce29ad03c612c2d952109f3f33b242435a645529c41115045b34", size = 3358896, upload-time = "2026-09-03T08:02:35.987Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/90/13bffa1518126597add8ab6ab32356ab69614f74392feeb303edfab306a3/arro3_core-0.8.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0bb9b3d5fdbb1f003de38c1de6c92a1e01494396e24d1ff89dd50c6e9e97f896", size = 3082548, upload-time = "2026-09-03T08:02:37.474Z" },
+    { url = "https://files.pythonhosted.org/packages/39/a6/92124aeea9b1268db7cf72b2ca37983774719cd6e2f4e7929db2073cfda5/arro3_core-0.8.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:866eeab0b4f9914b3c24afdee0d511f3e676698640f8c4edec3f0bf2f9dd1cbc", size = 3498273, upload-time = "2026-09-03T08:02:41.343Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/40/a89f5769487815ac84a082d502a207e0a8b43b3b78701564770b079e3dbd/arro3_core-0.8.2-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:ad3697ad4b5e3dcf12374a640348b76bdb31b32ffe623d3946fb201e2560f085", size = 3460783, upload-time = "2026-09-03T08:02:42.859Z" },
+    { url = "https://files.pythonhosted.org/packages/50/8c/d1e9747751ad34d0c5c91ec1b02474a44c9ab903e1a38f0e64490ac80403/arro3_core-0.8.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:fae5254eede746f18c575d8a8baff2da0dda15c43d10f9e099a5e46ba1c2a743", size = 3352750, upload-time = "2026-09-03T08:02:44.322Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fc/1e8d55efd0ff7b34a489132968a7508485dbfce96f632c76f48cb65368b5/arro3_core-0.8.2-cp314-cp314t-win_amd64.whl", hash = "sha256:7edc7ea86012638f5cd7d147b0155addd81255bbcbf5c6b1c2bd2643d523aa1f", size = 3290376, upload-time = "2026-09-03T08:02:45.927Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/2e/806752270276a9ccb3b9fdc16d3b64a7f551ddea9f3a42c00cb935691716/arro3_core-0.8.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f7bebb1f6630f203bd38e887db77d2780efd54ba3aadf2400b550c1660946cb2", size = 2944973, upload-time = "2026-09-03T08:02:47.681Z" },
+    { url = "https://files.pythonhosted.org/packages/77/7b/cc993ad965f42730a7b860613ed8c0b9ee6b0338aaa18163034bf4189b01/arro3_core-0.8.2-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:badb423ddec4885a094cf8c1a602e6f4282488c965c879ce7c14dc44eeaba28c", size = 3006013, upload-time = "2026-09-03T08:03:10.585Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/7c/237a2a0f271efde47aa4220747d912dc2ab980c405cb3f1f3c15cd668a33/arro3_core-0.8.2-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b6dea61d6507a37df1b9ea748ce1da77952703f5b3e310b9395917da2c9e3dc9", size = 2761746, upload-time = "2026-09-03T08:03:12.361Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/f2/b5ce96a781b0b576d39f389ede306907ff3d1333972cfbfadc45d56a3a9e/arro3_core-0.8.2-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f6f6fc755b220988c34acb1d76c0edc2568cd494d46f995bc0b7500365716795", size = 3236090, upload-time = "2026-09-03T08:03:13.818Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/96/b5984de2dac0cfa566e6d5671cf8818540b72d92fb5b4865e89f392963c7/arro3_core-0.8.2-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b9c392ebf9eacb5be13b93bd2313b1bf31185ce3598d61c24470df13ca9787df", size = 3344054, upload-time = "2026-09-03T08:03:15.546Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/6f/5d03d8b577f61826d8ff53ef9ff030e7594d45f603c3476e7d68c5b94f19/arro3_core-0.8.2-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:884f7b0a76f569681fb3433dafdaa84dbc8312fd235e76038982356d4365810e", size = 3486323, upload-time = "2026-09-03T08:03:17.077Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2c/7bde04fbdb48297c132c0db642ef94266d4b6fe4fc12cefb0017d8b8c660/arro3_core-0.8.2-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e80539b662c1ac48397de96cb8a9f6716bd6be04f5fef53c826b5d0507ed587", size = 3145312, upload-time = "2026-09-03T08:03:19.078Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2a/c6363c58fda54d5ecaddedd51a2f297eafe3e6854a4b2b7e233cfe4776c3/arro3_core-0.8.2-pp311-pypy311_pp73-manylinux_2_24_aarch64.whl", hash = "sha256:6544470e24831cb62d976358706db35d3b0c44b537775b3bc339e9eea3b4fe80", size = 2922585, upload-time = "2026-09-03T08:03:20.839Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/6d/cd96d0318b681e63fb6470fdadd8ca7be26669ab062e1370c8c5dd03e147/arro3_core-0.8.2-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:54a3e98a9bd158d454b79dae35b3bff47d66d5f991041e14598fe0bc2b8e1a2b", size = 3378312, upload-time = "2026-09-03T08:03:22.315Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/72/c0c32ef940ddcb35802d197e66b2f2dd8c3aa99072c871921a964c9b71fa/arro3_core-0.8.2-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:5c60a064c650dea38b4bc34dea8a0c578de96dd0197efe036c06792d93b7be56", size = 3100387, upload-time = "2026-09-03T08:03:23.868Z" },
+    { url = "https://files.pythonhosted.org/packages/50/12/4e7b8b59f24e14f3fff0b7f1b8148fdcc127c2d1bd0673830f117b252a57/arro3_core-0.8.2-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:61fc6088959f9918c8d780363aefb1f77ea8c34a24340c8ec657cdec1c53c53d", size = 3514801, upload-time = "2026-09-03T08:03:25.691Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/52/c08379366238eaabf2c352af1ed6f752794518996321c9291abe99d57291/arro3_core-0.8.2-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:5f484bc74703493d9af0f7ecab204962259023ee99fff485f49a76496b91bed4", size = 3482578, upload-time = "2026-09-03T08:03:27.418Z" },
+    { url = "https://files.pythonhosted.org/packages/89/9d/4d37156d136bf82d36089cf9d037fe47dcaccf6f997c763f7de283210dbd/arro3_core-0.8.2-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:fe4c8826f2fad626377440f43ac14378de45b09be049c26d00f102d1b53637b3", size = 3367140, upload-time = "2026-09-03T08:03:28.989Z" },
+]
+
+[[package]]
 name = "attr"
 version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -791,14 +844,14 @@ wheels = [
 
 [[package]]
 name = "mangum"
-version = "0.21.0"
+version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/cb/d9f4d685a0b8eceac10991e15ac471d9568e4e42c2489ae9bf072828c1c2/mangum-0.21.0.tar.gz", hash = "sha256:e31ed72d67f9958fa4379f65df77729906dec6dfa00afa6ed4e06c77833000de", size = 89130, upload-time = "2026-02-01T17:17:42.816Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/c8/1579c705908d02a4526a748e8d0f0419151d4498c59033840f5df3a14822/mangum-0.22.0.tar.gz", hash = "sha256:701936891aaed8ed66479b871c2bda87ba288fd01c7d5dd6ba6c8e9ba1c239d1", size = 118290, upload-time = "2026-08-22T12:54:48.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/50/e3c694b8e122551e4557450219283771334dee2ed5734a8398c8b8018c50/mangum-0.21.0-py3-none-any.whl", hash = "sha256:309e48f5c629542516c5106ecf079f4ec08809ed50df882238d98fe1392820c7", size = 17146, upload-time = "2026-02-01T17:17:41.553Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a2/21ee5d457ae79a2587ff0d4652990670b7cac84ba0eaab6e6865a3bd2515/mangum-0.22.0-py3-none-any.whl", hash = "sha256:a0595e3cc7a8091b22d8b3997bab5b2ad6aae7a5e40865e19c2015f5c959a93b", size = 17143, upload-time = "2026-08-22T12:54:46.924Z" },
 ]
 
 [[package]]
@@ -1925,20 +1978,22 @@ wheels = [
 
 [[package]]
 name = "rustac"
-version = "0.9.3"
+version = "0.9.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b1/dc/0c0618f576119fe1ac7b5b03a968a4a825411b0460f748039210e98c1dcd/rustac-0.9.3.tar.gz", hash = "sha256:427dc5325617d6c57f504318bc9f703763dc40df66d35a888d407d0ebc0f8c9f", size = 737820, upload-time = "2026-01-06T12:50:32.929Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/00/dfd09a5eb0681af8ed8136d52eb6056def889df33ef1db530419d0d33e1a/rustac-0.9.17.tar.gz", hash = "sha256:fd65e922e52f277d38f500f3e43fb7c76ea7ffb5d1209bc29a74a5c4754caf4d", size = 460116, upload-time = "2026-08-18T13:58:08.054Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/ef/d9698e162ffcbc47f172162d8f37a82f56c8afb7e3d48d10583952c6c29a/rustac-0.9.3-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d3cc8bed80370b54450377a53ebc33980ae59ec4e5fc37aea01ff29dc9133400", size = 25960779, upload-time = "2026-01-06T12:50:19.666Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/62/6bebac90e854f008cf4b5788698d8c568fa4184fd77cb3b3f9f45cdac546/rustac-0.9.3-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:2f9cf5f1fe536bd88c1fe2ac26d9d22a55e5143ac76a8af6b1ee8534b99dd9b7", size = 24090602, upload-time = "2026-01-06T12:50:17.183Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/2f/07edacb1b1a82b08cdaf5691442076f5852e40979859b116eae8802acbc3/rustac-0.9.3-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e1f6f94eaf0fd93d5f5f0687b73b43a9ada0e176eb6b4c8d279829892ccf9109", size = 28102224, upload-time = "2026-01-06T12:50:05.228Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/46/555e3fefe7f5775885e0d3765f10e035d0e540cc4253a493f29fda9da14b/rustac-0.9.3-cp311-abi3-manylinux_2_28_armv7l.whl", hash = "sha256:be326379c3e2599e1e02e02ff2c56fc3b324a9afd30bed1f0abfb03b33f3e6d1", size = 26388084, upload-time = "2026-01-06T12:50:08.089Z" },
-    { url = "https://files.pythonhosted.org/packages/82/1e/1c6e8ab14ef6066991232e9338ae42cb824376d22291e3d3c9741274eaca/rustac-0.9.3-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:288216ca0f96136afb8422e24728e19be535e6e34192b25763bfc374c98d72a9", size = 34572191, upload-time = "2026-01-06T12:50:10.682Z" },
-    { url = "https://files.pythonhosted.org/packages/46/0f/e41b599cd4f81e62b14b06b5c45b68ea52fb644f9e99d7791df5bd55bfc7/rustac-0.9.3-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:df941bdbaedaf6bf0b51976c923642c9bab55ed5a8e25a56bc49b02a11887f28", size = 31255045, upload-time = "2026-01-06T12:50:13.232Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/08/479539289c0e0de5095a8fd42308aa0669c3413f7590c5907137fd1a1f48/rustac-0.9.3-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:8e8355fa226d109be2be7aed485034eb69851fb6b59a9ed47af9379356b75825", size = 34678348, upload-time = "2026-01-06T12:50:22.632Z" },
-    { url = "https://files.pythonhosted.org/packages/14/19/53c5cbb4b7daa46abbb4f3db01f9fba619b73c20600eab9fc10ddcaed19b/rustac-0.9.3-cp311-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1a02d268580e7c6595563a2c3b3c8f12ee15411071ebcbd09f61f0325b64d46e", size = 34008454, upload-time = "2026-01-06T12:50:25.328Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/28/6606216351812a1bd9043dd6284216b3065af0a0f3d7deb00333ad4561db/rustac-0.9.3-cp311-abi3-musllinux_1_2_i686.whl", hash = "sha256:4b162fc0051dd440deb1bdfa4a9d3ea6726d0b3355f11c630a7528780178679a", size = 39073017, upload-time = "2026-01-06T12:50:27.863Z" },
-    { url = "https://files.pythonhosted.org/packages/56/7e/e3390934aa0a85fb7044fe8ca9c53868b55c0c2e996236e074b7c51ff429/rustac-0.9.3-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d3f3bb74f49acfbbce42be113dab300e98226b763974f7bbe94835bb90e7dcd6", size = 37084098, upload-time = "2026-01-06T12:50:30.696Z" },
+    { url = "https://files.pythonhosted.org/packages/80/76/7eaa45d16c8b17d520a665bc80566288dcb57ca5dc848bd168378f8d2d75/rustac-0.9.17-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f3e1885d44497bc553405343a69ac21cb9371311dae1ae63349a520d006d5e25", size = 28875390, upload-time = "2026-08-18T13:57:51.594Z" },
+    { url = "https://files.pythonhosted.org/packages/de/86/cae59c7628b2d6a0caa400280815054d3b4264d6b9602234dd056129280e/rustac-0.9.17-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:3bda15586db94be086bf492ddec17c5c1bac3dc5fd603076edea6c8ae4436332", size = 27071209, upload-time = "2026-08-18T13:57:48.58Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/c0/bd29ef33f5bb95bb9e442d4745d8cb89e0a0739a219f9f556d9ddce87484/rustac-0.9.17-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f14ed91cd7c2a879d97bea589bd5a69768075bd80d69a348bd4e0ed8deed55f0", size = 28878090, upload-time = "2026-08-18T13:57:36.081Z" },
+    { url = "https://files.pythonhosted.org/packages/99/b2/a09273d5d3a27377ef11153e98b1713647a381eacfd70124f80303ed7055/rustac-0.9.17-cp311-abi3-manylinux_2_28_armv7l.whl", hash = "sha256:cb4de4fe181b78bd9aa2834a6bd6460fc01c1fc800b0c681a87fb357004511e7", size = 27687729, upload-time = "2026-08-18T13:57:38.753Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/df/2941858d190d4a8fa63fad9a67e3d627bfb88716d79dea310af94af3c4e7/rustac-0.9.17-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:8ca0627cf58da1ba0be43b5be70a66abeea1172212d8062969f0d03a9aba95a4", size = 35798474, upload-time = "2026-08-18T13:57:41.8Z" },
+    { url = "https://files.pythonhosted.org/packages/80/44/799f69cfc09deca638fd08a3f58cb4405a6b9b76f3add121908b66f31325/rustac-0.9.17-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:d4846bda2f150e73e3600c8a19ff9d013b11714aaf90fd3494eb4429bf6928a7", size = 32418950, upload-time = "2026-08-18T13:57:45.419Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/74/fd4c252d52f3ba0e5e1beb2f9dd5665cd4c1903ff5c072c9e3ef126df5b3/rustac-0.9.17-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:72fa6c9096a1850c5e07f546954e345f7d5a79aa39386e5dd7563c32405af8df", size = 35423299, upload-time = "2026-08-18T13:57:54.754Z" },
+    { url = "https://files.pythonhosted.org/packages/41/7d/2980696da86613b8fe65a0c8505dca2a3e99ef27e23fcd304705d1e63a16/rustac-0.9.17-cp311-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c9cc83d9bc1380900b91f7a2841f21a22067acad3039c03b94574947f28dd680", size = 35431561, upload-time = "2026-08-18T13:57:59.067Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/84/cbec9a7a89413c5d181011ad5117dfdf728abd1011ec8ca82abb4edbaf45/rustac-0.9.17-cp311-abi3-musllinux_1_2_i686.whl", hash = "sha256:57a687f2d80e2218d907cf5b17a34dd8663c9128fa8f6f3123fd61ed7d3f9475", size = 40511950, upload-time = "2026-08-18T13:58:02.025Z" },
+    { url = "https://files.pythonhosted.org/packages/65/c0/2ae4c215202c2941ba7c40da9027cf34f0569760dbe2d59f1225912e4352/rustac-0.9.17-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:bd60f7551100eef0ddf3d6f138a2f1049c757ecd375a88001846e7d1e76644b2", size = 38179384, upload-time = "2026-08-18T13:58:05.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/f6/7080228e61fc85efdf60c4753ddde267afe2947080359e37a4a6075ab2aa/rustac-0.9.17-cp311-abi3-win32.whl", hash = "sha256:0eccaedcdf133c6318f8b8ab7e4af63184a9a8369b6259e8529119c3e6043c1c", size = 24582067, upload-time = "2026-08-18T13:58:13.077Z" },
+    { url = "https://files.pythonhosted.org/packages/75/4b/020856cd4f2ce85cc7077f5e84805f50307094196def58be6b462a440a63/rustac-0.9.17-cp311-abi3-win_amd64.whl", hash = "sha256:499599ff2f6f54fac5dbc025b98e764a04588e9b153baae2affc1cd68ec0cb30", size = 27465525, upload-time = "2026-08-18T13:58:09.78Z" },
 ]
 
 [[package]]
@@ -2099,9 +2154,10 @@ wheels = [
 
 [[package]]
 name = "stac-fastapi-geoparquet"
-version = "0.0.5"
+version = "0.0.6"
 source = { editable = "." }
 dependencies = [
+    { name = "arro3-core" },
     { name = "attr" },
     { name = "fastapi" },
     { name = "geojson-pydantic" },
@@ -2145,14 +2201,15 @@ validate = [
 
 [package.metadata]
 requires-dist = [
+    { name = "arro3-core", specifier = ">=0.8.0" },
     { name = "attr", specifier = ">=0.3.2" },
     { name = "fastapi", specifier = ">=0.115.8" },
     { name = "geojson-pydantic", specifier = ">=1.2.0" },
-    { name = "mangum", marker = "extra == 'lambda'", specifier = "==0.21.0" },
+    { name = "mangum", marker = "extra == 'lambda'", specifier = "==0.22.0" },
     { name = "obstore", specifier = ">=0.8.0" },
     { name = "pydantic", specifier = ">=2.10.4" },
     { name = "pystac", specifier = ">=1.13.0" },
-    { name = "rustac", specifier = ">=0.7.0" },
+    { name = "rustac", specifier = ">=0.9.11" },
     { name = "stac-fastapi-api", specifier = ">=5.0.2" },
     { name = "stac-fastapi-extensions", specifier = ">=5.0.2" },
     { name = "stac-fastapi-types", specifier = ">=5.0.2" },


### PR DESCRIPTION
Adds the Free-Text Search extension for item search. `q` becomes a CQL2 filter over the text columns of each collection's geoparquet — the set of columns differs per collection, so it's resolved inside the per-collection loop, and each file's schema is read once and cached by href. Structural members are excluded: matching every item because its `type` is `"Feature"` isn't what a free-text search means.

Semantics follow the extension: comma-separated terms, OR between them, case-insensitive partial matching (`CASEI(col) LIKE CASEI('%term%')`), and no special meaning for spaces. It works in both filter languages and ANDs with a caller-supplied `filter` rather than replacing it.

### Why the filter is built the way it is

The natural encoding is `filter AND (a OR b)`. rustac currently drops the grouping of a parenthesised OR nested under an AND on the way to SQL, so that form returns rows which fail the filter:

```python
client.search(href, filter='"naip:year"=\'2022\' AND ("naip:state"=\'ne\' OR "naip:state"=\'co\')')
# 9352 items, including 2021 and 2019 — the correct answer is 49
```

`cql2-json` is affected identically, so it isn't a text-parsing problem. This PR distributes the disjunction into `(filter AND a) OR (filter AND b)`, which needs no grouping to survive because SQL binds AND tighter than OR. My understanding is that a fix is already reported against rustac-py and waiting on a release; once that lands this can collapse back to the direct encoding, and `test_q_is_and_ed_with_a_filter` will keep the change honest.

### Incidental

Reading `q` also means reading the caller's filter language, spelled `"filter-lang"` on POST and `"filter_lang"` on GET, so both are consulted. Unset GET parameters are now dropped rather than forwarded as `None`, which otherwise reached the pagination links as the literal string `"None"`.

### Dependencies and overlap

Adds `arro3-core` and moves the rustac floor to `>=0.9.11` for `DuckdbClient.query_to_table`. `schema.py` and the small CQL2 quoting helpers are shared with the queryables and Query-extension PRs (identical content); whichever merges first, the others rebase cleanly.

### Verification

11 new tests. `scripts/lint` and `scripts/test` pass.
