### PR TITLE
fix: don't redirect trailing slashes

### DIFF
--- a/src/stac_fastapi/geoparquet/api.py
+++ b/src/stac_fastapi/geoparquet/api.py
@@ -180,6 +180,11 @@ def create(
         settings=settings,
         collections=collections,
         duckdb_client=duckdb_client,
+        # `/collections/` 404s rather than redirecting to `/collections`.
+        # Starlette builds the redirect's Location from the request's own
+        # host, which behind a proxy is the internal one, so the client is
+        # sent somewhere it can't reach.
+        redirect_slashes=False,
     )
     # Add hot-reload middleware
     app.middleware("http")(make_collections_middleware(settings))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -105,3 +105,10 @@ def test_duckdb_client_injected() -> None:
         response = client.get("/search")
         assert response.status_code == 200
         assert api.app.state.client is new_client
+
+
+def test_no_slash_redirect(client: TestClient) -> None:
+    # A trailing-slash redirect would send clients to the app's own host,
+    # which behind a proxy isn't reachable.
+    response = client.get("/collections/", follow_redirects=False)
+    assert response.status_code == 404


### PR DESCRIPTION
Starlette's trailing-slash redirect builds its `Location` header from the request's own host and scheme. Behind a proxy that's the app's internal address, so a client following the redirect from `/collections/` is sent somewhere it can't reach — and for an HTTPS proxy in front of an HTTP app, downgraded to plain HTTP on the way.

This returns 404 for the un-normalized path instead.

It is a behaviour change for anyone relying on the redirect, so it's split out on its own rather than bundled with other work — easy to drop if you'd rather keep the current behaviour.

### Verification

`scripts/lint` and `scripts/test` pass.
