### PR TITLE
refactor: give Client two extension points for subclasses

### DIFF
--- a/src/stac_fastapi/geoparquet/api.py
+++ b/src/stac_fastapi/geoparquet/api.py
@@ -12,6 +12,7 @@ import pystac.utils
 from fastapi import FastAPI, Request, Response
 from rustac import DuckdbClient
 from stac_fastapi.api.app import StacApi
+from stac_fastapi.types.core import BaseCoreClient
 from starlette.background import BackgroundTask
 
 from .client import Client
@@ -150,7 +151,13 @@ async def lifespan(app: FastAPI) -> AsyncIterator[State]:
 def create(
     settings: Settings | None = None,
     duckdb_client: DuckdbClient | None = None,
+    client: BaseCoreClient | None = None,
 ) -> StacApi:
+    """Build the STAC API application.
+
+    ``client`` defaults to :class:`~stac_fastapi.geoparquet.client.Client`;
+    pass a subclass to layer extra behaviour on top of it.
+    """
     if duckdb_client is None:
         duckdb_client = DuckdbClient()
     if settings is None:
@@ -186,7 +193,7 @@ def create(
 
     api = StacApi(
         settings=settings,
-        client=Client(),
+        client=client or Client(),
         app=app,
         search_get_request_model=GetSearchRequestModel,
         search_post_request_model=PostSearchRequestModel,

--- a/src/stac_fastapi/geoparquet/client.py
+++ b/src/stac_fastapi/geoparquet/client.py
@@ -21,9 +21,34 @@ DEFAULT_LIMIT = 10_000
 class Client(BaseCoreClient):
     """A stac-fastapi-geoparquet client."""
 
+    def visible_collections(self, request: Request) -> dict[str, Collection]:
+        """Return the collections this request is allowed to see.
+
+        Every endpoint reads its collections from here rather than from
+        ``request.state`` directly, so a subclass can hide some of them from a
+        caller by overriding this one method.
+        """
+        return cast(dict[str, Collection], request.state.collections)
+
+    def search_collection(
+        self,
+        collection_id: str,
+        href: str,
+        search_dict: dict[str, Any],
+        request: Request,
+    ) -> list[Item]:
+        """Run one collection's share of a search against its geoparquet.
+
+        The single point where a search reaches the DuckDB client, so a
+        subclass can adjust ``search_dict`` (extra filters, extra projected
+        columns) or post-process the items on the way back.
+        """
+        client = cast(DuckdbClient, request.state.client)
+        return cast(list[Item], client.search(href, **search_dict))
+
     def all_collections(self, **kwargs: Any) -> Collections:
         request = kwargs.pop("request")
-        collections = cast(dict[str, Collection], request.state.collections)
+        collections = self.visible_collections(request)
         return Collections(
             collections=[
                 collection_with_links(c, request) for c in collections.values()
@@ -44,11 +69,19 @@ class Client(BaseCoreClient):
 
     def get_collection(self, collection_id: str, **kwargs: Any) -> Collection:
         request = kwargs.pop("request")
-        collections = cast(dict[str, Collection], request.state.collections)
-        if collection := collections.get(collection_id):
-            return collection_with_links(collection, request)
-        else:
+        collection = self._get_collection(collection_id, request)
+        return collection_with_links(collection, request)
+
+    def _get_collection(self, collection_id: str, request: Request) -> Collection:
+        """Return the collection, or raise :class:`NotFoundError`.
+
+        A collection hidden by :meth:`visible_collections` is indistinguishable
+        from one that doesn't exist.
+        """
+        collection = self.visible_collections(request).get(collection_id)
+        if collection is None:
             raise NotFoundError(f"Collection does not exist: {collection_id}")
+        return collection
 
     def get_item(self, item_id: str, collection_id: str, **kwargs: Any) -> Item:
         item_collection = self.get_search(
@@ -120,6 +153,9 @@ class Client(BaseCoreClient):
     ) -> ItemCollection:
         request = kwargs.pop("request")
         offset = kwargs.pop("offset", None)
+        # 404 rather than an empty FeatureCollection for a collection that
+        # doesn't exist or that the caller isn't allowed to see.
+        self._get_collection(collection_id, request)
         search = PostSearchRequestModel(
             collections=[collection_id],
             bbox=bbox,
@@ -153,13 +189,14 @@ class Client(BaseCoreClient):
         search: BaseSearchPostRequest,
         **kwargs: Any,
     ) -> ItemCollection:
-        client = cast(DuckdbClient, request.state.client)
         hrefs = cast(dict[str, str], request.state.hrefs)
+        all_collections = self.visible_collections(request)
 
         if search.collections:
-            collections = search.collections
+            # Honour the request, minus anything not visible to this caller.
+            collections = [c for c in search.collections if c in all_collections]
         else:
-            collections = list(hrefs.keys())
+            collections = [c for c in hrefs if c in all_collections]
 
         search_dict = search.model_dump(exclude_none=True, by_alias=True)
         search_dict.update(**kwargs)
@@ -208,13 +245,13 @@ class Client(BaseCoreClient):
                         "offset": offset,
                     }
                 )
-                collection_items = client.search(href, **collection_search_dict)
+                collection_items = self.search_collection(
+                    collection, href, collection_search_dict, request
+                )
                 for item in collection_items:
                     # Careful ... we aren't updating `collection_items` with the
                     # correct links.
-                    items.append(
-                        self.item_with_links(cast(Item, item), request, collection)
-                    )
+                    items.append(self.item_with_links(item, request, collection))
                 if len(items) >= limit:
                     collections.insert(0, collection)
                     offset = offset + len(collection_items)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -105,3 +105,30 @@ def test_duckdb_client_injected() -> None:
         response = client.get("/search")
         assert response.status_code == 200
         assert api.app.state.client is new_client
+
+
+def test_create_with_a_client_subclass(extension_directory: Path) -> None:
+    from stac_fastapi.types.stac import Collection
+    from starlette.requests import Request
+
+    from stac_fastapi.geoparquet.client import Client
+
+    class OnlyNaip(Client):
+        def visible_collections(self, request: Request) -> dict[str, Collection]:
+            collections = super().visible_collections(request)
+            return {k: v for k, v in collections.items() if k == "naip"}
+
+    duckdb_client = DuckdbClient(extension_directory=str(extension_directory))
+    settings = Settings(stac_fastapi_collections_href=str(COLLECTIONS_PATH))
+    api = stac_fastapi.geoparquet.api.create(
+        duckdb_client=duckdb_client, settings=settings, client=OnlyNaip()
+    )
+    with TestClient(api.app) as client:
+        response = client.get("/collections")
+        assert [c["id"] for c in response.json()["collections"]] == ["naip"]
+
+        # A hidden collection is a 404, and searching it returns nothing.
+        assert client.get("/collections/openaerialmap").status_code == 404
+        assert client.get("/collections/openaerialmap/items").status_code == 404
+        response = client.get("/search", params={"collections": "openaerialmap"})
+        assert response.json()["features"] == []


### PR DESCRIPTION
Downstream deployments layer per-request rules on top of this client — hiding collections a caller may not see, restricting the rows a search returns, stripping an internal column on the way out. Doing that today means reimplementing `search()` wholesale, because the collection lookup and the call into DuckDB are inlined where a subclass can't reach them.

This adds two overridable methods, both no-ops by default:

- **`visible_collections(request)`** — the one place collections are read from request state, so a subclass can filter them and every endpoint follows.
- **`search_collection(collection_id, href, search_dict, request)`** — the one place a search reaches DuckDB, so a subclass can adjust the per-collection search or post-process its items.

`create()` also accepts the client to use, so a subclass can be wired in without rebuilding the app by hand.

### Behaviour

No change to what `/collections`, `/collections/{id}` and `/search` return. The one visible difference is that a collection hidden by an override 404s on `/collections/{id}/items` rather than returning an empty FeatureCollection, matching what `/collections/{id}` already does.

### Motivation

This is what lets our fork carry its access-control layer (a header-driven per-caller filter) as a small module of subclasses rather than a permanent patch to `client.py`. Posting it in case you'd rather have the seams upstream than have downstreams fork the file — entirely reasonable to decline if you'd prefer not to commit to the interface.

### Verification

New test wires in a `Client` subclass and checks the hidden collection is invisible across all four endpoints. `scripts/lint` and `scripts/test` pass.
